### PR TITLE
Social Support Network Map v2

### DIFF
--- a/media/css/ssnm.css
+++ b/media/css/ssnm.css
@@ -41,6 +41,13 @@
     background-color: #999;
 }
 
+.worth-ssnm-my-avatar-box {
+    width: 160px;
+    margin: 10px;
+    margin-top: 40px;
+    text-align: center;
+}
+
 .ssnm-modal-dialog {
     position: relative;
     top: 0;
@@ -79,5 +86,21 @@
     overflow-y: auto;
 }
 .ssnm-modal-footer {
+    border-top: 1px solid #e5e5e5;
     text-align: right;
+}
+
+.ssnm-modal-desc {
+    text-align: center;
+    font-size: 18px;
+}
+
+.ssnm-supporter-box {
+    border-radius: 10px;
+    background-color: white;
+    border: 1px solid black;
+    margin: 10px;
+    margin-top: 30px;
+    padding: 10px;
+    cursor: pointer;
 }

--- a/media/js/src/ssnm/components/modal-dialog.js
+++ b/media/js/src/ssnm/components/modal-dialog.js
@@ -1,0 +1,11 @@
+(function() {
+    'use strict';
+
+    Ssnm.ModalDialogComponent = Em.Component.extend({
+        actions: {
+            closeModal: function() {
+                return this.sendAction();
+            }
+        }
+    });
+})();

--- a/media/js/src/ssnm/controllers/supporter.js
+++ b/media/js/src/ssnm/controllers/supporter.js
@@ -1,0 +1,11 @@
+(function() {
+    'use strict';
+
+    Ssnm.SupporterController = Em.ObjectController.extend({
+        actions: {
+            editSupporter: function() {
+                Em.debug('editSupporter: ' + this.get('name'));
+            }
+        }
+    });
+})();

--- a/media/js/src/ssnm/controllers/supporters.js
+++ b/media/js/src/ssnm/controllers/supporters.js
@@ -1,0 +1,19 @@
+(function() {
+    'use strict';
+
+    Ssnm.SupportersController = Em.ArrayController.extend({
+        itemController: 'supporter',
+
+        veryCloseSupporters: Em.computed.filter('model', function(supporter) {
+            return supporter.get('closeness') === 'VC';
+        }).property('model.@each.closeness'),
+
+        closeSupporters: Em.computed.filter('model', function(supporter) {
+            return supporter.get('closeness') === 'C';
+        }).property('model.@each.closeness'),
+
+        notCloseSupporters: Em.computed.filter('model', function(supporter) {
+            return supporter.get('closeness') === 'NC';
+        }).property('model.@each.closeness')
+    });
+})();

--- a/media/js/src/ssnm/models/supporter.js
+++ b/media/js/src/ssnm/models/supporter.js
@@ -3,6 +3,11 @@
     'use strict';
 
     Ssnm.Supporter = DS.Model.extend({
-        name: DS.attr('string')
+        name: DS.attr('string'),
+        closeness: DS.attr('string'),
+        influence: DS.attr('string'),
+        getInfluenceDisplay: DS.attr('string'),
+        providesEmotionalSupport: DS.attr('boolean'),
+        providesPracticalSupport: DS.attr('boolean')
     });
 })();

--- a/media/js/src/ssnm/routes/application.js
+++ b/media/js/src/ssnm/routes/application.js
@@ -2,6 +2,8 @@
     'use strict';
 
     Ssnm.ApplicationRoute = Em.Route.extend({
+        controllerName: 'supporters',
+
         actions: {
             openModal: function(modalName) {
                 Em.debug('route:application openModal');
@@ -29,12 +31,12 @@
                     parentView: 'application'
                 });
             }
-        }
+        },
 
-        // TODO: auth for inactive users requires something other than
-        // django-rest-framework's SessionAuthentication
-        // model: function() {
-        //     return this.store.find('supporter');
-        // }
+        model: function() {
+            // Return all the supporters. The back-end will only return
+            // supporters that belong to the logged-in participant.
+            return this.store.find('supporter');
+        }
     });
 })();

--- a/media/js/src/ssnm/views/modal.js
+++ b/media/js/src/ssnm/views/modal.js
@@ -3,10 +3,12 @@
 
     Ssnm.ModalView = Em.View.extend({
         click: function(e) {
+            Em.debug('view:modal click');
             // If the user clicked on the shaded modal backdrop, close the
             // window.
-            if (Em.$(e.target).hasClass('roulette-modal')) {
-                return this.get('controller').send('closeModal');
+            if (Em.$(e.target).hasClass('ssnm-modal')) {
+                Em.debug('view:modal sending closeModal');
+                this.get('controller').send('closeModal');
             }
         }
     });

--- a/worth2/main/models.py
+++ b/worth2/main/models.py
@@ -18,6 +18,9 @@ class InactiveUserProfile(models.Model):
     created_at = models.DateTimeField(auto_now_add=True, editable=False)
     updated_at = models.DateTimeField(auto_now=True, editable=False)
 
+    def __unicode__(self):
+        return unicode(self.user.username)
+
     def is_participant(self):
         return (not self.user.is_active)
 
@@ -167,3 +170,6 @@ class Session(models.Model):
 
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
+
+    def __unicode__(self):
+        return unicode('Session for ' + self.participant.user.username)

--- a/worth2/settings_shared.py
+++ b/worth2/settings_shared.py
@@ -154,6 +154,8 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.BrowsableAPIRenderer',
     ),
 }
+REST_EMBER_FORMAT_KEYS = True
+REST_EMBER_PLURALIZE_KEYS = True
 
 PAGEBLOCKS = ['pageblocks.TextBlock',
               'pageblocks.HTMLBlock',

--- a/worth2/ssnm/apiviews.py
+++ b/worth2/ssnm/apiviews.py
@@ -1,12 +1,15 @@
 from rest_framework import viewsets
 
-from worth2.ssnm.auth import InactiveUserSessionAuthentication
-from worth2.ssnm.models import Supporter
+from worth2.ssnm.auth import (
+    InactiveUserSessionAuthentication, ParticipantPermission
+)
 from worth2.ssnm.serializers import SupporterSerializer
 
 
 class SupporterViewSet(viewsets.ModelViewSet):
-    authentication_classes = (InactiveUserSessionAuthentication,)
-    # TODO: filter for user
-    queryset = Supporter.objects.all()
     serializer_class = SupporterSerializer
+    authentication_classes = (InactiveUserSessionAuthentication,)
+    permission_classes = (ParticipantPermission,)
+
+    def get_queryset(self):
+        return self.request.user.profile.participant.supporters.all()

--- a/worth2/ssnm/auth.py
+++ b/worth2/ssnm/auth.py
@@ -1,9 +1,20 @@
 from rest_framework import authentication
+from rest_framework import permissions
 
 
 class InactiveUserSessionAuthentication(authentication.BaseAuthentication):
     """ Authenticate an inactive user, i.e. a Participant """
     def authenticate(self, request):
-        # TODO
+        # Get user from underlying HttpRequest, just like
+        # rest_framework.authentication.SessionAuthentication
+        request = request._request
         user = getattr(request, 'user', None)
         return (user, None)
+
+
+class ParticipantPermission(permissions.BasePermission):
+    """ Give participants permission. """
+    def has_permission(self, request, view):
+        user = getattr(request, 'user', None)
+        return user and hasattr(user, 'profile') and \
+            user.profile.is_participant()

--- a/worth2/ssnm/migrations/0002_auto_20150114_1431.py
+++ b/worth2/ssnm/migrations/0002_auto_20150114_1431.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ssnm', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='supporter',
+            name='participant',
+            field=models.ForeignKey(related_name='supporters', to='main.Participant'),
+            preserve_default=True,
+        ),
+    ]

--- a/worth2/ssnm/models.py
+++ b/worth2/ssnm/models.py
@@ -4,7 +4,7 @@ from worth2.main.models import Participant
 
 
 class Supporter(models.Model):
-    participant = models.ForeignKey(Participant)
+    participant = models.ForeignKey(Participant, related_name='supporters')
     name = models.TextField()
 
     closeness = models.CharField(
@@ -33,3 +33,6 @@ class Supporter(models.Model):
 
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
+
+    def __unicode__(self):
+        return unicode(self.name)

--- a/worth2/ssnm/serializers.py
+++ b/worth2/ssnm/serializers.py
@@ -6,5 +6,15 @@ from worth2.ssnm.models import Supporter
 class SupporterSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Supporter
-        fields = ('pk', 'participant', 'name', 'closeness', 'influence',
-                  'provides_emotional_support', 'provides_practical_support')
+        fields = (
+            # ember-data expects id, not pk. Fortunately in Django these
+            # terms are interchangeable.
+            'id',
+            'participant',
+            'name',
+            'closeness',
+            'influence',
+            'get_influence_display',
+            'provides_emotional_support',
+            'provides_practical_support'
+        )

--- a/worth2/ssnm/tests/test_apiviews.py
+++ b/worth2/ssnm/tests/test_apiviews.py
@@ -1,0 +1,31 @@
+from django.core.urlresolvers import reverse
+from rest_framework.test import APITestCase
+
+from worth2.ssnm.tests.factories import SupporterFactory
+from worth2.main.tests.mixins import LoggedInParticipantTestMixin
+
+
+class SupporterViewSetTest(LoggedInParticipantTestMixin, APITestCase):
+    def test_list(self):
+        SupporterFactory(participant=self.participant)
+        SupporterFactory(participant=self.participant)
+        SupporterFactory(participant=self.participant)
+        SupporterFactory()
+
+        r = self.client.get(reverse('supporter-list'))
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.data.get('count'), 3)
+
+    def test_retrieve(self):
+        supporter = SupporterFactory(participant=self.participant)
+        r = self.client.get(
+            reverse('supporter-detail', args=(supporter.pk,))
+        )
+        self.assertEqual(r.status_code, 200)
+
+    def test_retrieve_only_related_supporters(self):
+        supporter = SupporterFactory()
+        r = self.client.get(
+            reverse('supporter-detail', args=(supporter.pk,))
+        )
+        self.assertEqual(r.status_code, 404)

--- a/worth2/templates/ssnm/ssnm.html
+++ b/worth2/templates/ssnm/ssnm.html
@@ -16,46 +16,147 @@
     {{/view}}
 </script>
 
+<script type="text/x-handlebars" id="components/supporter-component">
+    <div class="ssnm-supporter-box" {{action 'editSupporter'}}>
+        <div class="pull-left">
+            <img src="placeholder.png" width="80" height="80" />
+        </div>
+        <div class="pull-right">
+            <h3>{{supporter.name}}</h3>
+            <div>{{supporter.getInfluenceDisplay}} Influence</div>
+            {{#if supporter.providesEmotionalSupport}}
+            <div style="color: magenta;">Emotional Support</div>
+            {{/if}}
+            {{#if supporter.providesPracticalSupport}}
+            <div style="color: blue;">Practical Support</div>
+            {{/if}}
+        </div>
+        <div class="clearfix"></div>
+    </div>
+</script>
+
 <script type="text/x-handlebars" data-template-name="application">
     <div class="worth-ssnm-container">
         <div class="worth-ssnm-box worth-ssnm-box-very-close">
             <div class="ssnm-title">My Social Support Network</div>
             <div class="ssnm-box-title">Very Close</div>
-            <div "worth-ssnm-my-avatar">
-                <img class="placeholder.png" width="200" height="200" />
+            <div class="worth-ssnm-my-avatar-box">
+                <img src="placeholder.png" width="150" height="150" />
                 <button type="button" class="btn btn-primary" name="add-people"
-                        {{action 'openModal' 'add-supporter-modal'}}>
+                        {{action 'openModal' 'edit-supporter-modal-1'}}>
                     Add People
                 </button>
             </div>
+
+            {{#each supporter in controller.veryCloseSupporters}}
+            {{supporter-component supporter=supporter}}
+            {{/each}}
         </div>
 
         <div class="worth-ssnm-box worth-ssnm-box-close">
             <div class="ssnm-box-title">Close</div>
+            {{#each supporter in controller.closeSupporters}}
+            {{supporter-component supporter=supporter}}
+            {{/each}}
         </div>
 
         <div class="worth-ssnm-box worth-ssnm-box-not-close">
             <div class="ssnm-box-title">Not Close</div>
+            {{#each supporter in controller.notCloseSupporters}}
+            {{supporter-component supporter=supporter}}
+            {{/each}}
         </div>
     </div>
 
     {{outlet 'modal'}}
 </script>
 
-<script type="text/x-handlebars" data-template-name="add-supporter-modal">
-    {{#modal-dialog action="closeModal"}}
+<script type="text/x-handlebars" data-template-name="edit-supporter-modal-1">
+    {{#modal-dialog action='closeModal'}}
     <div class="ssnm-modal-header">
         <h4>Add a New Person</h4>
     </div>
     <div class="ssnm-modal-body">
-        <p>
-            Test modal
+        <p class="ssnm-modal-desc">
+            Part 1 of 4: Who Is This?
+        </p>
+        <form>
+            <label for="ssnm-name" class="control-label">Name</label>
+            <input type="text" class="form-control" id="ssnm-name" />
+        </form>
+    </div>
+    <div class="ssnm-modal-footer">
+        <button {{action 'closeModal'}} class="btn btn-default">
+            Cancel
+        </button>
+        <button {{action 'closeModal'}} class="btn btn-primary">
+            Next
+        </button>
+    </div>
+    {{/modal-dialog}}
+</script>
+
+<script type="text/x-handlebars" data-template-name="edit-supporter-modal-2">
+    {{#modal-dialog action='closeModal'}}
+    <div class="ssnm-modal-header">
+        <h4>Add a New Person</h4>
+    </div>
+    <div class="ssnm-modal-body">
+        <p class="ssnm-modal-desc">
+            Part 2 of 4: Getting Close
         </p>
     </div>
     <div class="ssnm-modal-footer">
-        <button {{action "closeModal"}}
-                class="btn btn-primary">
-            OK
+        </button>
+                <button {{action 'closeModal'}} class="btn btn-default">
+            Cancel
+        </button>
+        <button {{action 'closeModal'}} class="btn btn-primary">
+            Next
+        </button>
+    </div>
+    {{/modal-dialog}}
+</script>
+
+<script type="text/x-handlebars" data-template-name="edit-supporter-modal-3">
+    {{#modal-dialog action='closeModal'}}
+    <div class="ssnm-modal-header">
+        <h4>Add a New Person</h4>
+    </div>
+    <div class="ssnm-modal-body">
+        <p class="ssnm-modal-desc">
+            Part 3 of 4: Influence
+        </p>
+    </div>
+    <div class="ssnm-modal-footer">
+        </button>
+                <button {{action 'closeModal'}} class="btn btn-default">
+            Cancel
+        </button>
+        <button {{action 'closeModal'}} class="btn btn-primary">
+            Next
+        </button>
+    </div>
+    {{/modal-dialog}}
+</script>
+
+<script type="text/x-handlebars" data-template-name="edit-supporter-modal-4">
+    {{#modal-dialog action='closeModal'}}
+    <div class="ssnm-modal-header">
+        <h4>Add a New Person</h4>
+    </div>
+    <div class="ssnm-modal-body">
+        <p class="ssnm-modal-desc">
+            Part 4 of 4: Support
+        </p>
+    </div>
+    <div class="ssnm-modal-footer">
+        </button>
+                <button {{action 'closeModal'}} class="btn btn-default">
+            Cancel
+        </button>
+        <button {{action 'closeModal'}} class="btn btn-primary">
+            Done
         </button>
     </div>
     {{/modal-dialog}}
@@ -71,9 +172,12 @@
 
 <script src="{{STATIC_URL}}js/src/ssnm/application.js"></script>
 <script src="{{STATIC_URL}}js/src/ssnm/adapters/application.js"></script>
+<script src="{{STATIC_URL}}js/src/ssnm/controllers/supporter.js"></script>
+<script src="{{STATIC_URL}}js/src/ssnm/controllers/supporters.js"></script>
 <script src="{{STATIC_URL}}js/src/ssnm/router.js"></script>
 <script src="{{STATIC_URL}}js/src/ssnm/routes/application.js"></script>
 <script src="{{STATIC_URL}}js/src/ssnm/models/supporter.js"></script>
+<script src="{{STATIC_URL}}js/src/ssnm/components/modal-dialog.js"></script>
 <script src="{{STATIC_URL}}js/src/ssnm/views/modal.js"></script>
 {% endblock %}
 

--- a/worth2/urls.py
+++ b/worth2/urls.py
@@ -32,7 +32,8 @@ rest_router = routers.DefaultRouter()
 rest_router.register(r'participants', apiviews.ParticipantViewSet)
 
 ssnm_rest_router = routers.DefaultRouter(trailing_slash=False)
-ssnm_rest_router.register(r'supporters', ssnm_apiviews.SupporterViewSet)
+ssnm_rest_router.register(r'supporters', ssnm_apiviews.SupporterViewSet,
+                          base_name='supporter')
 
 urlpatterns = patterns(
     '',


### PR DESCRIPTION
Participants' supporters now get loaded with ember-data and put in the
appropriate box in the support map.

I'm glad I found the rest_framework_ember package - it automatically
does all the tedious json format stuff that I did manually for Weather
Roulette.

The big thing left to implement is adding/editing supporters.

![2015-01-14-172556_973x432_scrot](https://cloud.githubusercontent.com/assets/59292/5748992/6c21f3d0-9c12-11e4-9bbb-c86a90aa2850.png)
