### PR TITLE
Use pagetree 1.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -62,7 +62,7 @@ django-ga-context==0.1.0
 django-impersonate==0.9
 django-registration==1.1
 django-treebeard==2.0
--e git://github.com/ccnmtl/django-pagetree.git#egg=django-pagetree
+django-pagetree==1.0.3
 django-pageblocks==1.0.0
 django-quizblock==1.0.0
 django-markwhat==2014.9.20


### PR DESCRIPTION
While setting up Marc's sandbox on kodos, there were problems
bootstrapping with a github URL in requirements.txt. Using a normal pip
package works, though.