### PR TITLE
Add supporter editing in SSNM activity - PMT #98027

### DIFF
--- a/media/js/src/ssnm/components/modal-dialog.js
+++ b/media/js/src/ssnm/components/modal-dialog.js
@@ -6,6 +6,7 @@
             // This is required for the closeModal action to get through
             // to the ApplicationRoute.
             closeModal: function() {
+                Em.debug('component:modal-dialog closeModal');
                 return this.sendAction();
             }
         }

--- a/media/js/src/ssnm/components/supporter-box.js
+++ b/media/js/src/ssnm/components/supporter-box.js
@@ -1,0 +1,11 @@
+(function() {
+    'use strict';
+
+    Ssnm.SupporterBoxComponent = Em.Component.extend({
+        click: function() {
+            Em.debug('component:supporter click');
+            var supporter = this.get('supporter');
+            return this.sendAction('clickedSupporter', supporter);
+        }
+    });
+})();

--- a/media/js/src/ssnm/controllers/edit-supporter.js
+++ b/media/js/src/ssnm/controllers/edit-supporter.js
@@ -8,6 +8,8 @@
      * "Add Supporter" dialogs.
      */
     Ssnm.EditSupporterController = Em.ObjectController.extend({
+        title: 'Add to your support network',
+
         hasBlankName: Em.computed.empty('name'),
         hasBlankCloseness: Em.computed.empty('closeness'),
         hasBlankInfluence: Em.computed.empty('influence'),

--- a/media/js/src/ssnm/controllers/supporter.js
+++ b/media/js/src/ssnm/controllers/supporter.js
@@ -1,11 +1,9 @@
 (function() {
     'use strict';
 
+    /**
+     * controller:supporter
+     */
     Ssnm.SupporterController = Em.ObjectController.extend({
-        actions: {
-            editSupporter: function() {
-                Em.debug('editSupporter: ' + this.get('name'));
-            }
-        }
     });
 })();

--- a/media/js/src/ssnm/controllers/supporters.js
+++ b/media/js/src/ssnm/controllers/supporters.js
@@ -5,14 +5,49 @@
      * controller:supporters
      *
      * This is the main application controller (it handles the
-     * ApplicationRoute). All it needs to do is put the supporters in 3
-     * different arrays based on closeness.
+     * ApplicationRoute).
      */
     Ssnm.SupportersController = Em.ArrayController.extend({
+        needs: ['edit-supporter'],
         itemController: 'supporter',
 
-        veryCloseSupporters: Em.computed.filterBy('model', 'closeness', 'VC'),
-        closeSupporters: Em.computed.filterBy('model', 'closeness', 'C'),
-        notCloseSupporters: Em.computed.filterBy('model', 'closeness', 'NC')
+        // An array of all supporters in the system that have been loaded
+        // from the back-end. This excludes the temporary supporter that
+        // exists only on the front-end, during the series of modals after
+        // clicking "Add People".
+        savedSupporters: Em.computed.filter('model', function(supporter) {
+            return !supporter.get('isNew');
+        }).property('model.@each.isNew'),
+
+        veryCloseSupporters: Em.computed.filterBy(
+            'savedSupporters', 'closeness', 'VC'),
+        closeSupporters: Em.computed.filterBy(
+            'savedSupporters', 'closeness', 'C'),
+        notCloseSupporters: Em.computed.filterBy(
+            'savedSupporters', 'closeness', 'NC'),
+
+        actions: {
+            addSupporter: function() {
+                Em.debug('controller:supporters addSupporter');
+                var editSupporterController = this.get(
+                    'controllers.edit-supporter');
+                editSupporterController.set(
+                    'model', this.store.createRecord('supporter'));
+                this.send('openModal', 'edit-supporter-modal-1');
+            },
+
+            /**
+             * This action occurs when a participant clicks on one of
+             * their existing supporters in the social support network
+             * map.
+             */
+            editSupporter: function(supporter) {
+                Em.debug('controller:supporters editSupporter');
+                var editSupporterController = this.get(
+                    'controllers.edit-supporter');
+                editSupporterController.set('model', supporter);
+                this.send('openModal', 'edit-supporter-modal-1');
+            }
+        }
     });
 })();

--- a/media/js/src/ssnm/routes/application.js
+++ b/media/js/src/ssnm/routes/application.js
@@ -29,9 +29,9 @@
                         controller: controllerName
                     });
                 } catch (e) {
-                    // If the custom modal controller doesn't exist, the previous
-                    // render statement throws an exception, and we use the base
-                    // modal controller.
+                    // If the custom modal controller doesn't exist, the
+                    // previous render statement throws an exception, and
+                    // we use the base modal controller.
                     Em.debug('Fell back to default controller');
                     return this.render(modalName, {
                         into: 'application',

--- a/worth2/templates/ssnm/ssnm.html
+++ b/worth2/templates/ssnm/ssnm.html
@@ -45,8 +45,8 @@ HTML template - there's probably a way of avoiding that step.
     {{/view}}
 </script>
 
-<script type="text/x-handlebars" id="components/supporter-component">
-    <div class="ssnm-supporter-box" {{action 'editSupporter'}}>
+<script type="text/x-handlebars" id="components/supporter-box">
+    <div class="ssnm-supporter-box">
         <div class="pull-left">
             <img src="placeholder.png" width="80" height="80" />
         </div>
@@ -72,27 +72,30 @@ HTML template - there's probably a way of avoiding that step.
             <div class="worth-ssnm-my-avatar-box">
                 <img src="placeholder.png" width="150" height="150" />
                 <button type="button" class="btn btn-primary" name="add-people"
-                        {{action 'openModal' 'edit-supporter-modal-1'}}>
+                        {{action "addSupporter"}}>
                     Add People
                 </button>
             </div>
 
             {{#each supporter in controller.veryCloseSupporters}}
-                {{supporter-component supporter=supporter}}
+                {{supporter-box supporter=supporter
+                clickedSupporter="editSupporter"}}
             {{/each}}
         </div>
 
         <div class="worth-ssnm-box worth-ssnm-box-close">
             <div class="ssnm-box-title">Close</div>
             {{#each supporter in controller.closeSupporters}}
-                {{supporter-component supporter=supporter}}
+                {{supporter-box supporter=supporter
+                clickedSupporter="editSupporter"}}
             {{/each}}
         </div>
 
         <div class="worth-ssnm-box worth-ssnm-box-not-close">
             <div class="ssnm-box-title">Not Close</div>
             {{#each supporter in controller.notCloseSupporters}}
-                {{supporter-component supporter=supporter}}
+                {{supporter-box supporter=supporter
+                clickedSupporter="editSupporter"}}
             {{/each}}
         </div>
     </div>
@@ -103,7 +106,7 @@ HTML template - there's probably a way of avoiding that step.
 <script type="text/x-handlebars" data-template-name="edit-supporter-modal-1">
     {{#modal-dialog action='closeModal'}}
     <div class="ssnm-modal-header">
-        <h4>Add a New Person</h4>
+        <h4>{{title}}</h4>
     </div>
     <div class="ssnm-modal-body">
         <p class="ssnm-modal-desc">
@@ -131,7 +134,7 @@ HTML template - there's probably a way of avoiding that step.
 <script type="text/x-handlebars" data-template-name="edit-supporter-modal-2">
     {{#modal-dialog action='closeModal'}}
     <div class="ssnm-modal-header">
-        <h4>Add a New Person</h4>
+        <h4>{{title}}</h4>
     </div>
     <div class="ssnm-modal-body">
         <p class="ssnm-modal-desc">
@@ -178,7 +181,7 @@ HTML template - there's probably a way of avoiding that step.
 <script type="text/x-handlebars" data-template-name="edit-supporter-modal-3">
     {{#modal-dialog action='closeModal'}}
     <div class="ssnm-modal-header">
-        <h4>Add a New Person</h4>
+        <h4>{{title}}</h4>
     </div>
     <div class="ssnm-modal-body">
         <p class="ssnm-modal-desc">
@@ -230,7 +233,7 @@ HTML template - there's probably a way of avoiding that step.
 <script type="text/x-handlebars" data-template-name="edit-supporter-modal-4">
     {{#modal-dialog action='closeModal'}}
     <div class="ssnm-modal-header">
-        <h4>Add a New Person</h4>
+        <h4>{{title}}</h4>
     </div>
     <div class="ssnm-modal-body">
         <p class="ssnm-modal-desc">
@@ -289,6 +292,7 @@ HTML template - there's probably a way of avoiding that step.
 <script src="{{STATIC_URL}}js/src/ssnm/views/modal.js"></script>
 <script src="{{STATIC_URL}}js/src/ssnm/views/radio-button.js"></script>
 <script src="{{STATIC_URL}}js/src/ssnm/components/modal-dialog.js"></script>
+<script src="{{STATIC_URL}}js/src/ssnm/components/supporter-box.js"></script>
 <script src="{{STATIC_URL}}js/src/ssnm/helpers/radio-button.js"></script>
 
 {% endblock %}


### PR DESCRIPTION
- Participants can now edit supporters by clicking on them
- Bugfix where supporter boxes were showing before being saved