### PR TITLE
Fix redirect loop

### DIFF
--- a/worth2/main/mixins.py
+++ b/worth2/main/mixins.py
@@ -1,8 +1,0 @@
-from django.contrib.auth.decorators import user_passes_test
-from django.utils.decorators import method_decorator
-
-
-class ActiveUserRequiredMixin(object):
-    @method_decorator(user_passes_test(lambda u: u.is_active))
-    def dispatch(self, *args, **kwargs):
-        return super(ActiveUserRequiredMixin, self).dispatch(*args, **kwargs)

--- a/worth2/main/tests/test_views.py
+++ b/worth2/main/tests/test_views.py
@@ -23,6 +23,22 @@ class AvatarSelectorTest(LoggedInParticipantTestMixin, TestCase):
         r = self.client.get(reverse('avatar-selector'))
         self.assertEqual(r.status_code, 200)
 
+    def test_participant_with_no_avatar(self):
+        h = get_hierarchy('main', '/pages/')
+        root = h.get_root()
+        root.add_child_section_from_dict({
+            'label': 'Section 1',
+            'slug': 'section-1',
+            'pageblocks': [],
+            'children': [],
+        })
+        r = self.client.get('/pages/section-1')
+
+        # Assert that a participant with no avatar is redirected to the
+        # avatar selector when attempting to navigate to pagetree
+        self.assertEqual(r.status_code, 302)
+        self.assertRedirects(r, reverse('avatar-selector'))
+
     def test_post(self):
         r = self.client.post(reverse('avatar-selector'), {
             'avatar_id': self.avatar1.pk

--- a/worth2/main/tests/test_views.py
+++ b/worth2/main/tests/test_views.py
@@ -53,7 +53,7 @@ class AvatarSelectorTest(LoggedInParticipantTestMixin, TestCase):
 class BasicTest(TestCase):
     def test_root(self):
         response = self.client.get("/")
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 200)
 
     def test_smoketest(self):
         response = self.client.get("/smoketest/")

--- a/worth2/urls.py
+++ b/worth2/urls.py
@@ -51,19 +51,21 @@ urlpatterns = patterns(
     (r'infranil/', include('infranil.urls')),
     (r'^uploads/(?P<path>.*)$',
      'django.views.static.serve', {'document_root': settings.MEDIA_ROOT}),
+
     (r'^pagetree/', include('pagetree.urls')),
     (r'^quizblock/', include('quizblock.urls')),
-    (r'^pages/edit/(?P<path>.*)$', user_passes_test(lambda u: u.is_superuser)(
-        EditView.as_view(
-            hierarchy_name="main",
-            hierarchy_base="/pages/")),
-     {}, 'edit-page'),
-    (r'^pages/instructor/(?P<path>.*)$',
+    url(r'^pages/edit/(?P<path>.*)$',
+        user_passes_test(lambda u: u.is_superuser)(
+            EditView.as_view(
+                hierarchy_name="main",
+                hierarchy_base="/pages/")),
+        {}, 'edit-page'),
+    url(r'^pages/instructor/(?P<path>.*)$',
         user_passes_test(lambda u: auth.user_is_facilitator(u))(
             InstructorView.as_view(
                 hierarchy_name="main",
                 hierarchy_base="/pages/"))),
-    (r'^pages/(?P<path>.*)$', views.ParticipantSessionPageView.as_view(
+    url(r'^pages/(?P<path>.*)$', views.ParticipantSessionPageView.as_view(
         hierarchy_name="main",
         hierarchy_base="/pages/")),
 


### PR DESCRIPTION
Fix redirect loop that occurs when a participant navigates to `/`.

- Removed ActiveUserRequiredMixin - it was just confusing things. For
  now, all auth is handled in urls.py. If it turns out that using mixins
  is more standard, I can switch everything over to that, but I
  shouldn't be using both mixins and urls.py for auth.

- Add participant with no avatar test