### PR TITLE
Goal checkin - PMT #98023

### DIFF
--- a/worth2/goals/forms.py
+++ b/worth2/goals/forms.py
@@ -1,0 +1,26 @@
+from django import forms
+from django.forms.formsets import formset_factory
+
+from worth2.goals.models import GoalCheckInOption
+
+
+class GoalCheckInForm(forms.Form):
+    i_will_do_this = forms.ChoiceField(
+        label='I will do this.',
+        choices=(
+            ('yes', 'Yes'),
+            ('no', 'No'),
+            ('in progress', 'In Progress'),
+        ),
+        widget=forms.RadioSelect,
+    )
+
+    what_got_in_the_way = forms.ModelChoiceField(
+        label='What got in the way?',
+        queryset=GoalCheckInOption.objects.all(),
+    )
+
+    other = forms.CharField()
+
+
+GoalCheckInFormSet = formset_factory(GoalCheckInForm, min_num=1)

--- a/worth2/goals/forms.py
+++ b/worth2/goals/forms.py
@@ -5,6 +5,8 @@ from worth2.goals.models import GoalCheckInOption
 
 
 class GoalCheckInForm(forms.Form):
+    goal_setting_response_id = forms.IntegerField(widget=forms.HiddenInput())
+
     i_will_do_this = forms.ChoiceField(
         label='I will do this.',
         choices=(
@@ -20,7 +22,7 @@ class GoalCheckInForm(forms.Form):
         queryset=GoalCheckInOption.objects.all(),
     )
 
-    other = forms.CharField()
+    other = forms.CharField(required=False)
 
 
 GoalCheckInFormSet = formset_factory(GoalCheckInForm, min_num=1)

--- a/worth2/goals/migrations/0009_auto_20150216_1411.py
+++ b/worth2/goals/migrations/0009_auto_20150216_1411.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('goals', '0008_auto_20150216_1057'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='GoalCheckInOption',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('order', models.PositiveIntegerField(editable=False, db_index=True)),
+                ('text', models.TextField(help_text=b'An option for the "What got in the way" dropdown for goal check-in.')),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                'ordering': ('order',),
+                'abstract': False,
+            },
+            bases=(models.Model,),
+        ),
+        migrations.AddField(
+            model_name='goalcheckinresponse',
+            name='what_got_in_the_way',
+            field=models.ForeignKey(default=None, to='goals.GoalOption'),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name='goalcheckinresponse',
+            name='goal_setting_response',
+            field=models.ForeignKey(to='goals.GoalSettingResponse', unique=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='goaloption',
+            name='text',
+            field=models.TextField(help_text=b'An option for the dropdowns in a specific GoalSetting pageblock.'),
+            preserve_default=True,
+        ),
+    ]

--- a/worth2/goals/migrations/0010_auto_20150216_1659.py
+++ b/worth2/goals/migrations/0010_auto_20150216_1659.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('goals', '0009_auto_20150216_1411'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='goalcheckinresponse',
+            name='what_got_in_the_way',
+            field=models.ForeignKey(to='goals.GoalCheckInOption'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='goalsettingblock',
+            name='session_num',
+            field=models.PositiveSmallIntegerField(default=1, help_text=b'The session this is associated with (i.e. 1 through 5).', db_index=True),
+            preserve_default=True,
+        ),
+    ]

--- a/worth2/goals/mixins.py
+++ b/worth2/goals/mixins.py
@@ -1,4 +1,8 @@
+from django import forms
+from django.forms.formsets import formset_factory
+
 from worth2.goals.forms import GoalCheckInFormSet
+from worth2.goals.models import GoalOption, GoalSettingResponse
 
 
 class GoalCheckInViewMixin(object):
@@ -13,3 +17,111 @@ class GoalCheckInViewMixin(object):
 
     def handle_goal_check_in_submission(self, request, goalcheckinblock):
         pass
+
+
+class GoalSettingViewMixin(object):
+    """Mixin for GoalSettingBlock form functionality.
+
+    This mixin should be attached to your custom PageView.
+    """
+
+    def create_goal_setting_formset(self, request, goalsettingblock):
+        """Create the goal setting formset.
+
+        To be used by GET and POST.
+        """
+
+        # I'd like to define the GoalSettingForm instead in
+        # goals/forms.py, but the goal field depends on data I can
+        # only get here.
+        class GoalSettingForm(forms.Form):
+            option = forms.ModelChoiceField(
+                label='Main services goal',
+                queryset=GoalOption.objects.filter(
+                    goal_setting_block=goalsettingblock.block()),
+                widget=forms.Select(attrs={'class': 'form-control'}),
+            )
+            text = forms.CharField(
+                widget=forms.Textarea(attrs={'rows': 3}),
+                label='How will you make this happen?',
+            )
+
+        # If there's existing responses to this pageblock, use them
+        # to bind the formset.
+        responses = GoalSettingResponse.objects.filter(
+            user=request.user,
+            goal_setting_block=goalsettingblock.block())
+
+        # Adapt to the strange behavior of formset_factory's "extra"
+        # param. The formset displays a different number of forms
+        # based on how many elements of initial data we give it, so
+        # we need to adjust "extra" based on "responses".
+        extra = goalsettingblock.block().goal_amount - 1
+        extra -= responses.count() - 1
+
+        self.GoalSettingFormSet = formset_factory(
+            GoalSettingForm,
+            extra=extra,
+            # min_num is 1 because there's always a 'Main' goal form.
+            min_num=1,
+            validate_min=True,
+        )
+
+        initial_data = []
+        for r in responses.order_by('form_id'):
+            initial_data.append({
+                'option': r.option,
+                'text': r.text,
+            })
+
+        self.formset = self.GoalSettingFormSet(
+            prefix='pageblock-%s' % goalsettingblock.pk,
+            initial=tuple(initial_data),
+        )
+
+    def handle_goal_setting_submission(self, request, goalsettingblock):
+        """Handle a submission for the goal setting activity.
+
+        This method returns the formset populated formset.
+        """
+
+        block = goalsettingblock.block()
+        formset = self.GoalSettingFormSet(
+            request.POST,
+            prefix='pageblock-%s' % goalsettingblock.pk)
+
+        if formset.is_valid():
+            for i, formdata in enumerate(formset.cleaned_data):
+                # Formsets with multiple forms put an empty dictionary in
+                # the cleaned data for unpopulated forms. We don't want
+                # to attempt to make a GoalSettingResponse for these
+                # optional, empty forms.
+                if formdata == {}:
+                    continue
+
+                option = formdata.get('option')
+                text = formdata.get('text')
+
+                updated_values = dict(option=option, text=text)
+                try:
+                    GoalSettingResponse.objects.update_or_create(
+                        form_id=i,
+                        user=request.user,
+                        goal_setting_block=block,
+                        defaults=updated_values)
+                except:
+                    # In case there's a unique_together exception, or something
+                    # similar, (which is unlikely, but possible if you have
+                    # stale data), we can handle it by refreshing the data.
+                    GoalSettingResponse.objects.filter(
+                        form_id=i,
+                        user=request.user,
+                        goal_setting_block=block,
+                    ).delete()
+
+                    updated_values['form_id'] = i
+                    updated_values['user'] = request.user
+                    updated_values['goal_setting_block'] = block
+                    GoalSettingResponse.objects.create(**updated_values)
+
+        return formset

--- a/worth2/goals/mixins.py
+++ b/worth2/goals/mixins.py
@@ -1,0 +1,15 @@
+from worth2.goals.forms import GoalCheckInFormSet
+
+
+class GoalCheckInViewMixin(object):
+    """Mixin for GoalCheckInPageBlock form functionality.
+
+    This mixin should be attached to your custom PageView.
+    """
+
+    def create_goal_check_in_formset(self, request, goalcheckinblock):
+        self.checkin_formset = GoalCheckInFormSet(
+            prefix='pageblock-%s' % goalcheckinblock.pk)
+
+    def handle_goal_check_in_submission(self, request, goalcheckinblock):
+        pass

--- a/worth2/goals/mixins.py
+++ b/worth2/goals/mixins.py
@@ -21,31 +21,19 @@ class GoalCheckInViewMixin(object):
         goalsettingblock = GoalSettingBlock.objects.get(
             session_num=goalcheckinblock.block().session_num)
 
-        goal_setting_responses = GoalSettingResponse.objects.filter(
+        self.goal_setting_responses = GoalSettingResponse.objects.filter(
             user=request.user,
             goal_setting_block=goalsettingblock)
 
-        # goal_check_in_responses = GoalCheckInResponse.objects.filter(
-        #    goal_setting_response__in=goal_setting_responses)
-
-        # Adapt to the strange behavior of formset_factory's "extra"
-        # param. The formset displays a different number of forms
-        # based on how many elements of initial data we give it, so
-        # we need to adjust "extra" based on "responses".
-        extra = goalsettingblock.goal_amount - 1
-        extra -= goal_setting_responses.count() - 1
-
-        extra = 2
         self.GoalCheckInFormSet = formset_factory(
             GoalCheckInForm,
-            min_num=1,
-            extra=extra)
+            min_num=self.goal_setting_responses.count())
 
         self.checkin_formset = self.GoalCheckInFormSet(
             prefix='pageblock-%s' % goalcheckinblock.pk)
 
         self.goal_checkin_context = zip(
-            goal_setting_responses, self.checkin_formset)
+            self.goal_setting_responses, self.checkin_formset)
 
     def handle_goal_check_in_submission(self, request, goalcheckinblock):
         formset = self.GoalCheckInFormSet(

--- a/worth2/goals/models.py
+++ b/worth2/goals/models.py
@@ -5,7 +5,6 @@ from django import forms
 from ordered_model.models import OrderedModel
 from pagetree.models import PageBlock
 
-from worth2.main.auth import user_is_participant
 from worth2.main.generic.models import BasePageBlock
 
 
@@ -26,7 +25,8 @@ class GoalSettingBlock(models.Model):
 
     session_num = models.PositiveSmallIntegerField(
         default=1,
-        help_text='The session this is associated with (i.e. 1 through 5).'
+        help_text='The session this is associated with (i.e. 1 through 5).',
+        db_index=True,
     )
 
     goal_type = models.CharField(
@@ -87,8 +87,7 @@ class GoalSettingBlock(models.Model):
                        unicode(self.pk))
 
     def submit(self, user, request_data):
-        if user_is_participant(user):
-            return
+        pass
 
 
 class GoalSettingBlockForm(forms.ModelForm):
@@ -152,7 +151,6 @@ class GoalCheckInResponse(models.Model):
     """
 
     goal_setting_response = models.ForeignKey(GoalSettingResponse, unique=True)
-
     i_will_do_this = models.CharField(
         max_length=255,
         choices=(
@@ -160,9 +158,7 @@ class GoalCheckInResponse(models.Model):
             ('no', 'No'),
             ('in progress', 'In Progress'),
         ))
-
     what_got_in_the_way = models.ForeignKey(GoalOption)
-
     other = models.TextField(blank=True, null=True)
 
     created_at = models.DateTimeField(auto_now_add=True)
@@ -229,6 +225,9 @@ class GoalCheckInPageBlock(BasePageBlock):
         form = GoalCheckInPageBlockForm(data=vals, files=files, instance=self)
         if form.is_valid():
             form.save()
+
+    def submit(self, user, request_data):
+        pass
 
 
 class GoalCheckInPageBlockForm(forms.ModelForm):

--- a/worth2/goals/models.py
+++ b/worth2/goals/models.py
@@ -100,7 +100,9 @@ class GoalOption(OrderedModel):
     """GoalSettingBlock dropdowns are populated by GoalOptions."""
 
     goal_setting_block = models.ForeignKey(GoalSettingBlock)
-    text = models.TextField()
+    text = models.TextField(
+        help_text='An option for the dropdowns in a specific ' +
+        'GoalSetting pageblock.')
 
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
@@ -128,6 +130,20 @@ class GoalSettingResponse(models.Model):
         unique_together = (('goal_setting_block', 'user', 'form_id'),)
 
 
+class GoalCheckInOption(OrderedModel):
+    """Editable options for the goal check-in form."""
+
+    text = models.TextField(
+        help_text='An option for the ' +
+        '"What got in the way" dropdown for goal check-in.')
+
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def __unicode__(self):
+        return unicode(self.text)
+
+
 class GoalCheckInResponse(models.Model):
     """Participant responses for the Check In page.
 
@@ -135,7 +151,7 @@ class GoalCheckInResponse(models.Model):
     This is only used on sessions 2 through 5.
     """
 
-    goal_setting_response = models.ForeignKey(GoalSettingResponse)
+    goal_setting_response = models.ForeignKey(GoalSettingResponse, unique=True)
 
     i_will_do_this = models.CharField(
         max_length=255,
@@ -144,6 +160,8 @@ class GoalCheckInResponse(models.Model):
             ('no', 'No'),
             ('in progress', 'In Progress'),
         ))
+
+    what_got_in_the_way = models.ForeignKey(GoalOption)
 
     other = models.TextField(blank=True, null=True)
 
@@ -191,6 +209,9 @@ class GoalCheckInPageBlock(BasePageBlock):
         default=1,
         help_text='The session this is associated with (i.e. 1 through 5).'
     )
+
+    def needs_submit(self):
+        return True
 
     @classmethod
     def add_form(cls):

--- a/worth2/goals/models.py
+++ b/worth2/goals/models.py
@@ -158,7 +158,7 @@ class GoalCheckInResponse(models.Model):
             ('no', 'No'),
             ('in progress', 'In Progress'),
         ))
-    what_got_in_the_way = models.ForeignKey(GoalOption)
+    what_got_in_the_way = models.ForeignKey(GoalCheckInOption)
     other = models.TextField(blank=True, null=True)
 
     created_at = models.DateTimeField(auto_now_add=True)

--- a/worth2/goals/tests/factories.py
+++ b/worth2/goals/tests/factories.py
@@ -2,15 +2,17 @@ import factory
 from factory.fuzzy import FuzzyText
 
 from worth2.goals.models import (
-    GoalCheckInOption, GoalOption, GoalSettingBlock
+    GoalCheckInOption, GoalCheckInPageBlock, GoalOption, GoalSettingBlock,
+    GoalSettingResponse
 )
+from worth2.main.tests.factories import UserFactory
 
 
 class GoalSettingBlockFactory(factory.DjangoModelFactory):
     class Meta:
         model = GoalSettingBlock
 
-    session = 1
+    session_num = 1
     goal_amount = 3
 
 
@@ -22,7 +24,24 @@ class GoalOptionFactory(factory.DjangoModelFactory):
     text = FuzzyText()
 
 
-class GoalCheckInFactory(factory.DjangoModelFactory):
+class GoalSettingResponseFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = GoalSettingResponse
+
+    goal_setting_block = factory.SubFactory(GoalSettingBlockFactory)
+    user = factory.SubFactory(UserFactory)
+    option = factory.SubFactory(GoalOptionFactory)
+    text = FuzzyText()
+
+
+class GoalCheckInBlockFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = GoalCheckInPageBlock
+
+    session_num = 1
+
+
+class GoalCheckInOptionFactory(factory.DjangoModelFactory):
     class Meta:
         model = GoalCheckInOption
 

--- a/worth2/goals/tests/factories.py
+++ b/worth2/goals/tests/factories.py
@@ -1,7 +1,9 @@
 import factory
 from factory.fuzzy import FuzzyText
 
-from worth2.goals.models import GoalOption, GoalSettingBlock
+from worth2.goals.models import (
+    GoalCheckInOption, GoalOption, GoalSettingBlock
+)
 
 
 class GoalSettingBlockFactory(factory.DjangoModelFactory):
@@ -17,4 +19,11 @@ class GoalOptionFactory(factory.DjangoModelFactory):
         model = GoalOption
 
     goal_setting_block = factory.SubFactory(GoalSettingBlockFactory)
+    text = FuzzyText()
+
+
+class GoalCheckInFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = GoalCheckInOption
+
     text = FuzzyText()

--- a/worth2/goals/tests/test_models.py
+++ b/worth2/goals/tests/test_models.py
@@ -1,0 +1,46 @@
+from django.test import TestCase
+
+from worth2.goals.tests.factories import (
+    GoalSettingBlockFactory, GoalOptionFactory, GoalSettingResponseFactory,
+    GoalCheckInBlockFactory, GoalCheckInOptionFactory
+)
+
+
+class GoalSettingBlockTest(TestCase):
+    def setUp(self):
+        self.o = GoalSettingBlockFactory()
+
+    def test_is_valid_from_factory(self):
+        self.o.full_clean()
+
+
+class GoalOptionTest(TestCase):
+    def setUp(self):
+        self.o = GoalOptionFactory()
+
+    def test_is_valid_from_factory(self):
+        self.o.full_clean()
+
+
+class GoalSettingResponseTest(TestCase):
+    def setUp(self):
+        self.o = GoalSettingResponseFactory()
+
+    def test_is_valid_from_factory(self):
+        self.o.full_clean()
+
+
+class GoalCheckInBlockTest(TestCase):
+    def setUp(self):
+        self.o = GoalCheckInBlockFactory()
+
+    def test_is_valid_from_factory(self):
+        self.o.full_clean()
+
+
+class GoalCheckInOptionTest(TestCase):
+    def setUp(self):
+        self.o = GoalCheckInOptionFactory()
+
+    def test_is_valid_from_factory(self):
+        self.o.full_clean()

--- a/worth2/goals/tests/test_views.py
+++ b/worth2/goals/tests/test_views.py
@@ -1,11 +1,219 @@
 from django.test import TestCase
 from pagetree.helpers import get_hierarchy
 
-from worth2.goals.tests.factories import GoalOptionFactory
-from worth2.goals.models import GoalSettingResponse
+from worth2.goals.tests.factories import (
+    GoalCheckInOptionFactory, GoalOptionFactory, GoalSettingResponseFactory
+)
+from worth2.goals.models import (
+    GoalCheckInResponse, GoalSettingBlock, GoalSettingResponse
+)
+from worth2.main.tests.helpers import unlock_hierarchy
 from worth2.main.tests.mixins import (
     LoggedInParticipantTestMixin
 )
+
+
+class GoalCheckInBlockTest(LoggedInParticipantTestMixin, TestCase):
+    def setUp(self):
+        super(GoalCheckInBlockTest, self).setUp()
+
+        self.h = get_hierarchy('main', '/pages/')
+        self.root = self.h.get_root()
+
+        # These blocks will be associated because they both default to
+        # 'session_num' = 1.
+        # Put Goal Check In before Goal Setting (opposite of what
+        # actually will happen on production) to get around the
+        # fact that the goal setting page has needs_submit == True.
+        self.root.add_child_section_from_dict({
+            'label': 'Goal Setting Section',
+            'slug': 'goal-setting-section',
+            'pageblocks': [{
+                'block_type': 'Goal Setting Block',
+            }],
+            'children': [],
+        })
+        self.root.add_child_section_from_dict({
+            'label': 'Goal Check In Section',
+            'slug': 'goal-check-in-section',
+            'pageblocks': [{
+                'block_type': 'Goal Check In Block',
+            }],
+            'children': [],
+        })
+        unlock_hierarchy(self.root.get_first_child(), self.u)
+
+        self.url = '/pages/goal-check-in-section/'
+
+        goalsettingblock = \
+            self.root.get_first_child().pageblock_set.first()
+        opt1 = GoalOptionFactory(goal_setting_block=goalsettingblock.block())
+        opt2 = GoalOptionFactory(goal_setting_block=goalsettingblock.block())
+        opt3 = GoalOptionFactory(goal_setting_block=goalsettingblock.block())
+        self.assertEqual(GoalSettingBlock.objects.count(), 1)
+
+        self.setting_resp1 = GoalSettingResponseFactory(
+            user=self.u,
+            form_id=0,
+            goal_setting_block=goalsettingblock.block(),
+            option=opt1,
+        )
+        self.setting_resp2 = GoalSettingResponseFactory(
+            user=self.u,
+            form_id=1,
+            goal_setting_block=goalsettingblock.block(),
+            option=opt2,
+        )
+        self.setting_resp3 = GoalSettingResponseFactory(
+            user=self.u,
+            form_id=2,
+            goal_setting_block=goalsettingblock.block(),
+            option=opt3,
+        )
+        self.setting_responses = [
+            self.setting_resp1, self.setting_resp2, self.setting_resp3
+        ]
+        self.assertEqual(GoalSettingBlock.objects.count(), 1)
+
+        self.goalcheckinblock = \
+            self.root.get_first_child().get_next().pageblock_set.first()
+
+        self.checkin_opt1 = GoalCheckInOptionFactory()
+        self.checkin_opt2 = GoalCheckInOptionFactory()
+        self.checkin_opt3 = GoalCheckInOptionFactory()
+
+        p = 'pageblock-%s' % self.goalcheckinblock.pk
+        self.valid_post_data = {
+            # Formset Management form params
+            '%s-TOTAL_FORMS' % p: '4',
+            '%s-INITIAL_FORMS' % p: '0',
+            '%s-MIN_NUM_FORMS' % p: '3',
+            '%s-MAX_NUM_FORMS' % p: '1000',
+
+            '%s-0-goal_setting_response_id' % p: self.setting_resp1.pk,
+            '%s-0-i_will_do_this' % p: 'yes',
+            '%s-0-what_got_in_the_way' % p: self.checkin_opt2.pk,
+            '%s-0-other' % p: 'form 1',
+
+            '%s-1-goal_setting_response_id' % p: self.setting_resp2.pk,
+            '%s-1-i_will_do_this' % p: 'no',
+            '%s-1-what_got_in_the_way' % p: self.checkin_opt1.pk,
+            '%s-1-other' % p: 'form 2',
+
+            '%s-2-goal_setting_response_id' % p: self.setting_resp3.pk,
+            '%s-2-i_will_do_this' % p: 'in progress',
+            '%s-2-what_got_in_the_way' % p: self.checkin_opt3.pk,
+            '%s-2-other' % p: 'form 3',
+        }
+
+    def test_get(self):
+        r = self.client.get(self.url)
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, 'Goal Check In Section')
+        self.assertContains(r, 'My Goals')
+        self.assertContains(r, 'Here\'s what you committed to do')
+        self.assertContains(r, 'class="goal-check-in"')
+
+    def test_post(self):
+        r = self.client.post(self.url, self.valid_post_data)
+
+        responses = GoalCheckInResponse.objects.filter(
+            goal_setting_response__in=self.setting_responses,
+        )
+
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(responses.count(), 3)
+
+        self.assertEqual(responses.first().what_got_in_the_way,
+                         self.checkin_opt2)
+        self.assertEqual(responses.all()[1].what_got_in_the_way,
+                         self.checkin_opt1)
+        self.assertEqual(responses.last().what_got_in_the_way,
+                         self.checkin_opt3)
+
+        self.assertEqual(responses.first().i_will_do_this, 'yes')
+        self.assertEqual(responses.all()[1].i_will_do_this, 'no')
+        self.assertEqual(responses.last().i_will_do_this, 'in progress')
+
+        self.assertEqual(responses.first().other, 'form 1')
+        self.assertEqual(responses.all()[1].other, 'form 2')
+        self.assertEqual(responses.last().other, 'form 3')
+
+    def test_post_only_main_goal(self):
+        """
+        Assert that a submission with only the Main form populated
+        doesn't validate.
+        """
+
+        p = 'pageblock-%s' % self.goalcheckinblock.pk
+        r = self.client.post(self.url, {
+            # Formset Management form params
+            '%s-TOTAL_FORMS' % p: '4',
+            '%s-INITIAL_FORMS' % p: '0',
+            '%s-MIN_NUM_FORMS' % p: '3',
+            '%s-MAX_NUM_FORMS' % p: '1000',
+
+            '%s-0-goal_setting_response_id' % p: self.setting_resp1.pk,
+            '%s-0-i_will_do_this' % p: 'no',
+            '%s-0-what_got_in_the_way' % p: self.checkin_opt2.pk,
+            '%s-0-other' % p: 'other text for form 1',
+        })
+
+        responses = GoalCheckInResponse.objects.filter(
+            goal_setting_response=self.setting_resp1,
+        )
+
+        self.assertEqual(responses.count(), 0)
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, 'required')
+        self.assertFormsetError(
+            r, 'checkin_formset', 1, 'i_will_do_this',
+            'This field is required.')
+        self.assertFormsetError(
+            r, 'checkin_formset', 2, 'i_will_do_this',
+            'This field is required.')
+
+    def test_post_multiple_times(self):
+        """
+        Assert that updating the first form in the formset multiple
+        times doesn't create multiple responses for it.
+        """
+
+        self.client.post(self.url, self.valid_post_data)
+
+        p = 'pageblock-%s' % self.goalcheckinblock.pk
+        new_post_data = self.valid_post_data.copy()
+        new_post_data.update({
+            '%s-0-other' % p: 'Updated!'
+        })
+        r = self.client.post(self.url, new_post_data)
+
+        self.assertEqual(r.status_code, 302)
+
+        responses = GoalCheckInResponse.objects.filter(
+            goal_setting_response=self.setting_resp1,
+        )
+        self.assertEqual(responses.count(), 1)
+
+        # Assert that the last update took effect.
+        self.assertEqual(responses.first().other, 'Updated!')
+
+    def test_post_invalid(self):
+        p = 'pageblock-%s' % self.goalcheckinblock.pk
+        invalid_post_data = self.valid_post_data.copy()
+        invalid_post_data.update({'%s-0-i_will_do_this' % p: None})
+        r = self.client.post(self.url, invalid_post_data)
+
+        responses = GoalCheckInResponse.objects.filter(
+            goal_setting_response=self.setting_resp1,
+        )
+        self.assertEqual(responses.count(), 0)
+
+        self.assertEqual(r.status_code, 200)
+        self.assertFormsetError(
+            r, 'checkin_formset', 0, 'i_will_do_this',
+            'Select a valid choice. None is not one of the ' +
+            'available choices.')
 
 
 class GoalSettingBlockTest(LoggedInParticipantTestMixin, TestCase):

--- a/worth2/main/tests/helpers.py
+++ b/worth2/main/tests/helpers.py
@@ -1,0 +1,19 @@
+from pagetree.models import UserPageVisit
+
+
+def unlock_hierarchy(section, user):
+    """Visit all sections in a Pagetree node to unlock everything.
+
+    Get around 'gated = True' by creating a UserPageVisit for each
+    section.
+    """
+
+    if section is None:
+        return
+
+    UserPageVisit.objects.create(
+        user=user,
+        section=section,
+        status='complete')
+
+    unlock_hierarchy(section.get_first_child(), user)

--- a/worth2/main/views.py
+++ b/worth2/main/views.py
@@ -230,7 +230,14 @@ class ParticipantSessionPageView(
         elif goalcheckinblock:
             formset = self.handle_goal_check_in_submission(
                 request, goalcheckinblock)
-            print '!'
+            if not formset.is_valid():
+                ctx = self.get_context_data()
+                ctx.update({
+                    'checkin_formset': formset,
+                    'goal_checkin_context': zip(
+                        self.goal_setting_responses, formset),
+                })
+                return render(request, self.template_name, ctx)
 
         return super(ParticipantSessionPageView, self).post(
             request, *args, **kwargs)

--- a/worth2/main/views.py
+++ b/worth2/main/views.py
@@ -138,8 +138,8 @@ class ParticipantSessionPageView(
     def get_first_block_of_type(self, blocktype):
         """Get the first block of type `blocktype` on this page.
 
-        Returns the goal check-in block if this page contains it.
-        Otherwise, returns None.
+        Returns the block if this page contains it. Otherwise, returns
+        None.
 
         Example usage:
             self.get_first_block_of_type('goal setting block')
@@ -162,7 +162,10 @@ class ParticipantSessionPageView(
         if goalsettingblock:
             ctx.update({'formset': self.formset})
         elif goalcheckinblock:
-            ctx.update({'formset': self.checkin_formset})
+            ctx.update({
+                'checkin_formset': self.checkin_formset,
+                'goal_checkin_context': self.goal_checkin_context,
+            })
 
         return ctx
 

--- a/worth2/templates/goals/goal_check_in_block.html
+++ b/worth2/templates/goals/goal_check_in_block.html
@@ -9,9 +9,9 @@
     <p>Here's what you committed to do during the last session.</p>
 
     <form class="form-horizontal" method="post">{% csrf_token %}
-        {{ formset.management_form }}
+        {{ checkin_formset.management_form }}
 
-        {% for form in formset %}
+        {% for t in goal_checkin_context %}
         <div class="well">
             <div class="form-group">
                 <label class="control-label col-sm-2">
@@ -19,7 +19,7 @@
                 </label>
                 <div class="col-sm-10">
                     <p class="form-control-static">
-                        Talk to a trustworthy person about things.
+                        {{ t.0.option }}
                     </p>
                 </div>
             </div>
@@ -29,11 +29,11 @@
                 </label>
                 <div class="col-sm-10">
                     <p class="form-control-static">
-                        I will text Sheila for coffee.
+                        {{ t.0.text }}
                     </p>
                 </div>
             </div>
-            {{ form|bootstrap_horizontal }}
+            {{ t.1|bootstrap_horizontal }}
         </div>
         {% endfor %}
 

--- a/worth2/templates/goals/goal_check_in_block.html
+++ b/worth2/templates/goals/goal_check_in_block.html
@@ -8,6 +8,42 @@
 
     <p>Here's what you committed to do during the last session.</p>
 
+    <form class="form-horizontal" method="post">{% csrf_token %}
+        {{ formset.management_form }}
+
+        {% for form in formset %}
+        <div class="well">
+            <div class="form-group">
+                <label class="control-label col-sm-2">
+                    My Support Goal
+                </label>
+                <div class="col-sm-10">
+                    <p class="form-control-static">
+                        Talk to a trustworthy person about things.
+                    </p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="control-label col-sm-2">
+                    I will do this.
+                </label>
+                <div class="col-sm-10">
+                    <p class="form-control-static">
+                        I will text Sheila for coffee.
+                    </p>
+                </div>
+            </div>
+            {{ form|bootstrap_horizontal }}
+        </div>
+        {% endfor %}
+
+        <div class="form-group">
+            <div class="col-sm-10">
+                <button type="submit" class="btn btn-primary">Submit</button>
+            </div>
+        </div>
+    </form>
+
     <div class="col-sm-2 avatar-block">
         <img src="{% avatar_url user %}">
     </div>

--- a/worth2/templates/goals/goal_review_block.html
+++ b/worth2/templates/goals/goal_review_block.html
@@ -12,19 +12,23 @@
         <form class="form-horizontal">
             <div class="well">
                 <div class="form-group">
-                    <label class="col-sm-3">
+                    <label class="control-label col-sm-3">
                         My Main Support Goal
                     </label>
                     <div class="col-sm-7">
-                        Talk to a trustworthy person about things.
+                        <p class="form-control-static">
+                            Talk to a trustworthy person about things.
+                        </p>
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-sm-3">
+                    <label class="control-label col-sm-3">
                         I will do this.
                     </label>
                     <div class="col-sm-7">
-                        I will talk to Pastor Debbie.
+                        <p class="form-control-static">
+                            I will talk to Pastor Debbie.
+                        </p>
                     </div>
                 </div>
                 <button class="btn btn-primary">Edit Goal</button>

--- a/worth2/templates/goals/goal_setting_block.html
+++ b/worth2/templates/goals/goal_setting_block.html
@@ -31,7 +31,7 @@
             {% endfor %}
 
             <div class="form-group">
-                <label class="col-sm-4 control-label"></label>
+                <label class="col-sm-2 control-label"></label>
                 <div class="col-sm-4">
                     <button type="submit" class="btn btn-primary">Submit</button>
                 </div>


### PR DESCRIPTION
This adds the goal check-in activity:

![2015-02-16-222258_797x465_scrot](https://cloud.githubusercontent.com/assets/59292/6222880/467bc728-b62a-11e4-85ce-81b5f633baa4.png)

This also includes a refactor of my PageView form customizations -- separating a lot of that logic out to `/worth2/goals/mixins.py`. There's also tests for the check-in activity and all the goal-related factories now.