### PR TITLE
Remove inaccurate comment

### DIFF
--- a/worth2/goals/tests/test_views.py
+++ b/worth2/goals/tests/test_views.py
@@ -22,9 +22,6 @@ class GoalCheckInBlockTest(LoggedInParticipantTestMixin, TestCase):
 
         # These blocks will be associated because they both default to
         # 'session_num' = 1.
-        # Put Goal Check In before Goal Setting (opposite of what
-        # actually will happen on production) to get around the
-        # fact that the goal setting page has needs_submit == True.
         self.root.add_child_section_from_dict({
             'label': 'Goal Setting Section',
             'slug': 'goal-setting-section',


### PR DESCRIPTION
I got around gating in the tests with the 'unlock_hierarchy' test
helper, not the section ordering.