### PR TITLE
Fix avatar selector form submission - PMT #99521

### DIFF
--- a/worth2/templates/main/avatar_selector_block.html
+++ b/worth2/templates/main/avatar_selector_block.html
@@ -5,13 +5,15 @@
 {% lorem 1 p %}
 
 <div class="worth-avatars">
-    {% for avatar in block.avatars %}
-    <span class="worth-avatar">
-        <img src="{{ avatar.image.url }}" />
-    </span>
-    <button class="btn btn-default" type="submit"
-            name="pageblock-{{block.pageblock.pk}}-avatar-id"
-            value="{{ avatar.pk }}"
-            >This is me!</button>
-    {% endfor %}
+    <form method="post" action=".">{% csrf_token %}
+        {% for avatar in block.avatars %}
+        <span class="worth-avatar">
+            <img src="{{ avatar.image.url }}" />
+        </span>
+        <button class="btn btn-default" type="submit"
+                name="pageblock-{{block.pageblock.pk}}-avatar-id"
+                value="{{ avatar.pk }}"
+                >This is me!</button>
+        {% endfor %}
+    </form>
 </div>


### PR DESCRIPTION
For some reason, pagetree isn't creating its page-wide `<form>`
for the avatar selector block. I have needs_submit set to true
for this custom pageblock.

I've seen this happen in other places of worth as well - the goal
forms needed my own `<form>` tag in the template.