### PR TITLE
Attach SSNM's Supporter to User instead of Participant - PMT #98027

### DIFF
--- a/worth2/ssnm/apiviews.py
+++ b/worth2/ssnm/apiviews.py
@@ -1,17 +1,16 @@
-from rest_framework import viewsets
+from rest_framework import viewsets, permissions
 
-from worth2.ssnm.auth import InactiveUserSessionAuthentication
-from worth2.main.auth import IsParticipantPermission
+from worth2.ssnm.auth import AnySessionAuthentication
 from worth2.ssnm.serializers import SupporterSerializer
 
 
 class SupporterViewSet(viewsets.ModelViewSet):
     serializer_class = SupporterSerializer
-    authentication_classes = (InactiveUserSessionAuthentication,)
-    permission_classes = (IsParticipantPermission,)
+    authentication_classes = (AnySessionAuthentication,)
+    permission_classes = (permissions.IsAuthenticated,)
 
     def get_queryset(self):
-        return self.request.user.profile.participant.supporters.all()
+        return self.request.user.supporters.all()
 
     def perform_create(self, serializer):
-        serializer.save(participant=self.request.user.profile.participant)
+        serializer.save(user=self.request.user)

--- a/worth2/ssnm/auth.py
+++ b/worth2/ssnm/auth.py
@@ -1,11 +1,22 @@
-from rest_framework import authentication
+from rest_framework.authentication import SessionAuthentication
 
 
-class InactiveUserSessionAuthentication(authentication.BaseAuthentication):
-    """ Authenticate an inactive user, i.e. a Participant """
+class AnySessionAuthentication(SessionAuthentication):
+    """Authenticate any user, whether active or inactive.
+
+    This is very similar to django-rest-framework's
+    SessionAuthentication. The only difference is that this will
+    authenticate users who are inactive as well as active.
+
+    Participants are inactive in worth, so this lets them use SSNM's API.
+    """
+
     def authenticate(self, request):
         # Get user from underlying HttpRequest, just like
         # rest_framework.authentication.SessionAuthentication
         request = request._request
         user = getattr(request, 'user', None)
+
+        self.enforce_csrf(request)
+
         return (user, None)

--- a/worth2/ssnm/migrations/0004_auto_20150218_0927.py
+++ b/worth2/ssnm/migrations/0004_auto_20150218_0927.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('ssnm', '0003_ssnmpageblock'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='supporter',
+            name='participant',
+        ),
+        migrations.AddField(
+            model_name='supporter',
+            name='user',
+            field=models.ForeignKey(related_name='supporters', to=settings.AUTH_USER_MODEL, null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/worth2/ssnm/models.py
+++ b/worth2/ssnm/models.py
@@ -1,12 +1,12 @@
 from django import forms
+from django.contrib.auth.models import User
 from django.db import models
 
-from worth2.main.models import Participant
 from worth2.main.generic.models import BasePageBlock
 
 
 class Supporter(models.Model):
-    participant = models.ForeignKey(Participant, related_name='supporters')
+    user = models.ForeignKey(User, null=True, related_name='supporters')
     name = models.TextField()
 
     closeness = models.CharField(

--- a/worth2/ssnm/tests/factories.py
+++ b/worth2/ssnm/tests/factories.py
@@ -1,7 +1,7 @@
 import factory
 from factory.fuzzy import FuzzyText
 
-from worth2.main.tests.factories import ParticipantFactory
+from worth2.main.tests.factories import UserFactory
 from worth2.ssnm.models import Supporter
 
 
@@ -9,5 +9,5 @@ class SupporterFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Supporter
 
-    participant = factory.SubFactory(ParticipantFactory)
+    user = factory.SubFactory(UserFactory)
     name = FuzzyText()

--- a/worth2/ssnm/tests/test_apiviews.py
+++ b/worth2/ssnm/tests/test_apiviews.py
@@ -8,9 +8,9 @@ from worth2.main.tests.mixins import LoggedInParticipantTestMixin
 
 class SupporterViewSetTest(LoggedInParticipantTestMixin, APITestCase):
     def test_list(self):
-        SupporterFactory(participant=self.participant)
-        SupporterFactory(participant=self.participant)
-        SupporterFactory(participant=self.participant)
+        SupporterFactory(user=self.u)
+        SupporterFactory(user=self.u)
+        SupporterFactory(user=self.u)
         SupporterFactory()
 
         r = self.client.get(reverse('supporter-list'))
@@ -18,7 +18,7 @@ class SupporterViewSetTest(LoggedInParticipantTestMixin, APITestCase):
         self.assertEqual(r.data.get('count'), 3)
 
     def test_retrieve(self):
-        supporter = SupporterFactory(participant=self.participant)
+        supporter = SupporterFactory(user=self.u)
         r = self.client.get(
             reverse('supporter-detail', args=(supporter.pk,))
         )
@@ -52,3 +52,34 @@ class SupporterViewSetTest(LoggedInParticipantTestMixin, APITestCase):
         self.assertEqual(supporter.name, 'Supporter name')
         self.assertEqual(supporter.provides_emotional_support, True)
         self.assertEqual(supporter.provides_practical_support, False)
+
+
+class SupporterViewSetUnAuthedTest(APITestCase):
+    def test_list(self):
+        SupporterFactory()
+        SupporterFactory()
+
+        r = self.client.get(reverse('supporter-list'))
+        self.assertEqual(r.status_code, 403)
+
+    def test_retrieve(self):
+        supporter = SupporterFactory()
+        r = self.client.get(
+            reverse('supporter-detail', args=(supporter.pk,))
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_create(self):
+        r = self.client.post(
+            reverse('supporter-list'),
+            {
+                'closeness': 'NC',
+                'influence': 'N',
+                'name': 'Supporter name',
+                'provides_emotional_support': True,
+                'provides_practical_support': False,
+            }
+        )
+
+        self.assertEqual(r.status_code, 403)
+        self.assertEqual(Supporter.objects.count(), 0)


### PR DESCRIPTION
I'm moving the relation on Supporter from Participant to a normal
django User, so all authenticated users can use the SSNM activity.