### PR TITLE
Fix stale cohort ID bug - PMT #99554

### DIFF
--- a/worth2/main/forms.py
+++ b/worth2/main/forms.py
@@ -3,8 +3,28 @@ from django import forms
 from worth2.main.models import Location, Participant
 
 
+class RawModelChoiceIterator(forms.models.ModelChoiceIterator):
+    def choice(self, obj):
+        return obj
+
+
+class RawModelChoiceField(forms.ModelChoiceField):
+    """
+    A ModelChoiceField that returns the model instance instead of
+    a single field.
+    """
+
+    def _get_choices(self):
+        if hasattr(self, '_choices'):
+            return self._choices
+
+        return RawModelChoiceIterator(self)
+
+    choices = property(_get_choices, forms.ChoiceField._set_choices)
+
+
 class SignInParticipantForm(forms.Form):
-    participant_id = forms.ModelChoiceField(
+    participant_id = RawModelChoiceField(
         label='Participant ID #',
         empty_label=None,
         queryset=Participant.objects.filter(

--- a/worth2/main/tests/factories.py
+++ b/worth2/main/tests/factories.py
@@ -47,6 +47,7 @@ class ParticipantFactory(factory.django.DjangoModelFactory):
     first_location = factory.SubFactory(LocationFactory)
     location = factory.SubFactory(LocationFactory)
     study_id = FuzzyText(prefix='7')
+    is_archived = False
 
 
 class SessionFactory(factory.django.DjangoModelFactory):

--- a/worth2/main/tests/test_views.py
+++ b/worth2/main/tests/test_views.py
@@ -152,6 +152,37 @@ class SignInParticipantAuthedTest(LoggedInFacilitatorTestMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['cohorts'], [])
 
+    def test_get_has_correct_data(self):
+        """
+        Test that when updating a participant's cohort ID on the
+        management page then visiting the sign-in page, the participant
+        dropdown has the correct cohort ID.
+        """
+
+        p1 = ParticipantFactory(cohort_id='367')
+        response = self.client.get(reverse('manage-participants'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, p1.study_id)
+        self.assertContains(response, p1.cohort_id)
+
+        p1.cohort_id = '389'
+        p1.save()
+
+        response = self.client.get(reverse('sign-in-participant'))
+        self.assertContains(response, 'Sign In a Participant')
+        self.assertEqual(response.status_code, 200)
+
+        self.assertContains(
+            response, '<option value="%s"' % p1.cohort_id,
+            msg_prefix='Incorrect cohort dropdown cohort ID')
+        self.assertEqual(response.context['cohorts'], [p1.cohort_id])
+
+        # TODO: Why is the participant ID dropdown empty here?
+        # self.assertContains(response, p1.study_id)
+        # self.assertContains(
+        #     response, 'data-cohort-id="%s"' % p1.cohort_id,
+        #     msg_prefix='Incorrect participant dropdown cohort ID')
+
     def test_valid_form_submit(self):
         location = LocationFactory()
         participant = ParticipantFactory()

--- a/worth2/templates/main/facilitator_sign_in_participant.html
+++ b/worth2/templates/main/facilitator_sign_in_participant.html
@@ -39,7 +39,7 @@
                         name="participant_id">
 
                     <option>Choose a Participant</option>
-                    {% for p in form.participant_id.field.queryset %}
+                    {% for p in form.participant_id.field.choices %}
                     <option value="{{p.pk}}"
                             data-cohort-id="{{p.cohort_id|default:''}}">
                         {{p.study_id}}</option>


### PR DESCRIPTION
This was solved by iterating over the form's "choices" instead of its
"queryset". "choices" is what django expects you to iterate over.

I was iterating over "queryset" as a sort of workaround, because I
need to populate the dropdown with the study ID as well as the cohort ID,
and I didn't know how to get ModelChoiceField to give me the whole object.

I added the RawModelChoiceField as a ModelChoiceField that gives the
whole instance to the template, instead of a single field.

The test for this is not quite complete since I ran into a problem where
I can't see the participant ID dropdown in the test.