### PR TITLE
Fix error display on sign-in form. PMT #99556

### DIFF
--- a/worth2/templates/main/facilitator_sign_in_participant.html
+++ b/worth2/templates/main/facilitator_sign_in_participant.html
@@ -14,8 +14,6 @@
           action="">
         {% csrf_token %}
 
-        {{ form.errors }}
-
         <div class="form-group">
             <label for="sign-in-cohort-filter"
                    class="control-label col-sm-3">Filter by Cohort</label>
@@ -30,7 +28,7 @@
             </div>
         </div>
 
-        <div class="form-group">
+        <div class="form-group {% if form.participant_id.errors %}has-error{% endif %}">
             <label class="control-label col-sm-3"
                    for="{{form.participant_id.id_for_label}}">
                 Participant ID #</label>
@@ -45,6 +43,9 @@
                         {{p.study_id}}</option>
                     {% endfor %}
                 </select>
+                {% for error in form.participant_id.errors %}
+                <span class="help-block">{{ error }}</span>
+                {% endfor %}
             </div>
         </div>
 


### PR DESCRIPTION
I wasn't displaying this form field's errors correctly. It looks better now:

![2015-02-23-094004_627x138_scrot](https://cloud.githubusercontent.com/assets/59292/6329624/0e2f2200-bb40-11e4-87d0-7b40c5d12410.png)
