### PR TITLE
Add customized feedback for the ratemyrisk quiz - PMT #98028

### DIFF
--- a/worth2/protectivebehaviors/templatetags/quizsummary.py
+++ b/worth2/protectivebehaviors/templatetags/quizsummary.py
@@ -6,7 +6,34 @@ from worth2.main.views import get_quiz_blocks
 register = template.Library()
 
 
-class PositiveQuizResponses(template.Node):
+def get_positive_responses_from_blocks(blocks, user):
+    """
+    Returns the responses to the quizzes in param 'blocks' that have
+    positive values (i.e. greater than 0).
+
+    The returned array is sorted by value, descending.
+    """
+
+    positive_answers = []
+    for b in blocks:
+        # assumption: each of these quiz types has one question
+        latest_submission = Submission.objects.filter(
+            quiz=b.content_object, user=user).order_by('-submitted').first()
+
+        if latest_submission:
+            positive_responses = Response.objects.filter(
+                submission=latest_submission, value__gte=1)
+            for r in positive_responses:
+                positive_answers.append(r)
+
+    sorted_answers = sorted(positive_answers,
+                            key=lambda answer: answer.value,
+                            reverse=True)
+    return sorted_answers
+
+
+@register.assignment_tag
+def get_quiz_summary(user, cls):
     """Aggregate a yes/no quiz by collecting all positive responses.
 
     The Quiz this works on is expected to be implemented as a series of
@@ -14,39 +41,20 @@ class PositiveQuizResponses(template.Node):
     false.
     """
 
-    def __init__(self, user, quiz_class, var_name):
-        self.user = user
-        self.quiz_class = quiz_class
-        self.var_name = var_name
-
-    def render(self, context):
-        u = context[self.user]
-        cls = context[self.quiz_class]
-
-        blocks = get_quiz_blocks(cls)
-
-        positive_answers = []
-        for b in blocks:
-            # assumption: each of these quiz types has one question
-            latest_submission = Submission.objects.filter(
-                quiz=b.content_object, user=u).order_by('-submitted').first()
-
-            if latest_submission:
-                positive_responses = Response.objects.filter(
-                    submission=latest_submission, value__gte=1)
-                for r in positive_responses:
-                    positive_answers.append(r)
-
-        sorted_answers = sorted(positive_answers,
-                                key=lambda answer: answer.value,
-                                reverse=True)
-        context[self.var_name] = sorted_answers
-        return ''
+    return get_positive_responses_from_blocks(get_quiz_blocks(cls), user)
 
 
-@register.tag('get_quiz_summary')
-def quizsummary(parser, token):
-    user = token.split_contents()[1:][0]
-    quiz_class = token.split_contents()[1:][1]
-    var_name = token.split_contents()[1:][3]
-    return PositiveQuizResponses(user, quiz_class, var_name)
+@register.assignment_tag
+def get_aggregate_level(user, cls):
+    """
+    Returns the max value for responses for 'user' on pageblocks associated
+    with the css class 'cls'.
+    """
+
+    responses = get_positive_responses_from_blocks(get_quiz_blocks(cls), user)
+
+    level = 0
+    for r in responses:
+        level = max(r.value, level)
+
+    return int(level)

--- a/worth2/protectivebehaviors/tests/test_templatetags.py
+++ b/worth2/protectivebehaviors/tests/test_templatetags.py
@@ -1,17 +1,16 @@
-from django.template import Context
 from django.test import TestCase
 from pagetree.helpers import get_hierarchy
 from quizblock.models import Response, Submission
 
 from worth2.main.tests.mixins import LoggedInParticipantTestMixin
 from worth2.protectivebehaviors.templatetags.quizsummary import (
-    PositiveQuizResponses
+    get_quiz_summary, get_aggregate_level
 )
 
 
-class PositiveQuizResponsesTest(LoggedInParticipantTestMixin, TestCase):
+class QuizSummaryTest(LoggedInParticipantTestMixin, TestCase):
     def setUp(self):
-        super(PositiveQuizResponsesTest, self).setUp()
+        super(QuizSummaryTest, self).setUp()
         self.hierarchy = get_hierarchy('main', '/pages/')
         self.root = self.hierarchy.get_root()
         self.root.add_child_section_from_dict({
@@ -60,6 +59,24 @@ class PositiveQuizResponsesTest(LoggedInParticipantTestMixin, TestCase):
                                 'correct': False,
                             },
                         ],
+                    },
+                    {
+                        'text': 'Question 3',
+                        'question_type': 'single choice',
+                        'explanation': '',
+                        'intro_text': '',
+                        'answers': [
+                            {
+                                'value': 2,
+                                'label': 'I do this.',
+                                'correct': False,
+                            },
+                            {
+                                'value': 0,
+                                'label': 'I don\'t do this.',
+                                'correct': False,
+                            },
+                        ],
                     }
                 ],
             }],
@@ -68,8 +85,9 @@ class PositiveQuizResponsesTest(LoggedInParticipantTestMixin, TestCase):
         self.quizblock = self.root.get_first_child().pageblock_set.first()
         self.question_1 = self.quizblock.block().question_set.first()
         self.question_2 = self.quizblock.block().question_set.all()[1]
+        self.question_3 = self.quizblock.block().question_set.last()
 
-    def test_basic_render(self):
+    def test_quizsummary(self):
         submission = Submission.objects.create(quiz=self.quizblock.block(),
                                                user=self.u)
 
@@ -78,19 +96,11 @@ class PositiveQuizResponsesTest(LoggedInParticipantTestMixin, TestCase):
             question=self.question_1,
             value='1')
 
-        n = PositiveQuizResponses('user', 'cls', 'results')
+        results = get_quiz_summary(self.u, 'protective-behaviors')
 
-        context = Context({
-            'question': self.question_1,
-            'user': self.u,
-            'cls': 'protective-behaviors',
-        })
-        out = n.render(context)
+        self.assertEqual(len(results), 1)
 
-        self.assertEqual(out, '')
-        self.assertEqual(len(context['results']), 1)
-
-    def test_render_only_shows_positive_values(self):
+    def test_quizsummary_only_shows_positive_values(self):
         submission = Submission.objects.create(quiz=self.quizblock.block(),
                                                user=self.u)
         Response.objects.create(
@@ -102,19 +112,11 @@ class PositiveQuizResponsesTest(LoggedInParticipantTestMixin, TestCase):
             question=self.question_2,
             value='0')
 
-        n = PositiveQuizResponses('user', 'cls', 'results')
+        results = get_quiz_summary(self.u, 'protective-behaviors')
 
-        context = Context({
-            'question': self.question_1,
-            'user': self.u,
-            'cls': 'protective-behaviors',
-        })
-        out = n.render(context)
+        self.assertEqual(len(results), 1)
 
-        self.assertEqual(out, '')
-        self.assertEqual(len(context['results']), 1)
-
-    def test_render_sorts_by_value(self):
+    def test_quizsummary_sorts_by_value(self):
         submission = Submission.objects.create(quiz=self.quizblock.block(),
                                                user=self.u)
         Response.objects.create(
@@ -126,18 +128,59 @@ class PositiveQuizResponsesTest(LoggedInParticipantTestMixin, TestCase):
             question=self.question_2,
             value='3')
 
-        n = PositiveQuizResponses('user', 'cls', 'results')
+        results = get_quiz_summary(self.u, 'protective-behaviors')
 
-        context = Context({
-            'question': self.question_1,
-            'user': self.u,
-            'cls': 'protective-behaviors',
-        })
-        out = n.render(context)
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0].question.text, 'Question 2')
+        self.assertEqual(results[0].value, '3')
+        self.assertEqual(results[1].question.text, 'Question 1')
+        self.assertEqual(results[1].value, '1')
 
-        self.assertEqual(out, '')
-        self.assertEqual(len(context['results']), 2)
-        self.assertEqual(context['results'][0].question.text, 'Question 2')
-        self.assertEqual(context['results'][0].value, '3')
-        self.assertEqual(context['results'][1].question.text, 'Question 1')
-        self.assertEqual(context['results'][1].value, '1')
+    def test_get_aggregate_level(self):
+        submission = Submission.objects.create(quiz=self.quizblock.block(),
+                                               user=self.u)
+        Response.objects.create(
+            submission=submission,
+            question=self.question_1,
+            value='1')
+        Response.objects.create(
+            submission=submission,
+            question=self.question_2,
+            value='0')
+
+        level = get_aggregate_level(self.u, 'protective-behaviors')
+        self.assertEqual(level, 1)
+
+    def test_get_aggregate_level_2(self):
+        submission = Submission.objects.create(quiz=self.quizblock.block(),
+                                               user=self.u)
+        Response.objects.create(
+            submission=submission,
+            question=self.question_1,
+            value='0')
+        Response.objects.create(
+            submission=submission,
+            question=self.question_2,
+            value='0')
+
+        level = get_aggregate_level(self.u, 'protective-behaviors')
+        self.assertEqual(level, 0)
+
+    def test_get_aggregate_level_3(self):
+        submission = Submission.objects.create(quiz=self.quizblock.block(),
+                                               user=self.u)
+        Response.objects.create(
+            submission=submission,
+            question=self.question_1,
+            value='0')
+        Response.objects.create(
+            submission=submission,
+            question=self.question_3,
+            value='2')
+        Response.objects.create(
+            submission=submission,
+            question=self.question_2,
+            value='0')
+
+        level = get_aggregate_level(self.u, 'protective-behaviors')
+        self.assertEqual(level, 2)

--- a/worth2/templates/protectivebehaviors/whats_your_level_feedback.html
+++ b/worth2/templates/protectivebehaviors/whats_your_level_feedback.html
@@ -1,0 +1,21 @@
+{% load quizsummary %}
+
+{# This is the 'Your level' feedback that looks at the Stuff I Do aggregate #}
+
+{% get_aggregate_level user 'protective-behaviors' as level %}
+
+{% if level == 3 %}
+<p>
+    Some of the stuff you do is high risk. It would be a good idea to think
+    about some ways to keep yourself safer.
+</p>
+{% elif level == 2 %}
+<p>
+    Some of the stuff you do is mildly risky.
+</p>
+{% else %}
+<p>
+    Great! It doesn't sound like you're involved in any of the
+    dangerous sexual activity we addressed.
+</p>
+{% endif %}

--- a/worth2/templates/quizblock/question.html
+++ b/worth2/templates/quizblock/question.html
@@ -3,6 +3,10 @@
 
 {% getquestionresponse question as response %}
 
+{% if 'rate-my-risk' in question.quiz.pageblock.css_extra %}
+    {% include 'protectivebehaviors/whats_your_level_feedback.html' %}
+{% endif %}
+
 <div class="cases">
   {{question.intro_text|markdown}}
 


### PR DESCRIPTION
In the process, I refactored the get_quiz_summary templatetag. I
simplified it a lot by using the @register.assignment_tag decorator.

![2015-02-24-211200_564x165_scrot](https://cloud.githubusercontent.com/assets/59292/6363627/8f975d7e-bc69-11e4-9e59-171ff67aa0e1.png)
