### PR TITLE
Add gating for locked pageblocks - PMT #99684

### DIFF
--- a/media/js/src/views/unlocker.js
+++ b/media/js/src/views/unlocker.js
@@ -4,7 +4,7 @@ define([
     'backbone'
 ], function($, _, Backbone) {
     /**
-     * This view unlocks the page's next button.
+     * This view unlocks the page's "Next" button.
      */
     var Unlocker = Backbone.View.extend({
         unlock: function() {
@@ -12,8 +12,9 @@ define([
         },
         initialize: function() {
             if ($('#youtube-player').length === 0) {
-                // TODO: leave this disabled for other gated pageblocks.
-                this.unlock();
+                if (isSectionUnlocked === 1) {
+                    this.unlock();
+                }
             } else {
                 // There's a video on the page, so find out if the user
                 // has already watched it.

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ django-ga-context==0.1.0
 django-impersonate==0.9
 django-registration==1.1
 django-treebeard==2.0
-django-pagetree==1.0.7
+django-pagetree==1.0.8
 django-pageblocks==1.0.0
 django-quizblock==1.0.3
 django-markwhat==2014.9.20

--- a/worth2/goals/migrations/0015_auto_20150227_1212.py
+++ b/worth2/goals/migrations/0015_auto_20150227_1212.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('goals', '0014_auto_20150220_1446'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='goalsettingresponse',
+            name='goal_setting_block',
+            field=models.ForeignKey(related_name='goal_setting_responses', to='goals.GoalSettingBlock'),
+            preserve_default=True,
+        ),
+    ]

--- a/worth2/goals/migrations/0016_auto_20150227_1224.py
+++ b/worth2/goals/migrations/0016_auto_20150227_1224.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('goals', '0015_auto_20150227_1212'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='goalcheckinresponse',
+            name='goal_setting_response',
+            field=models.ForeignKey(related_name='goal_checkin_response', to='goals.GoalSettingResponse', unique=True),
+            preserve_default=True,
+        ),
+    ]

--- a/worth2/main/generic/models.py
+++ b/worth2/main/generic/models.py
@@ -19,17 +19,53 @@ class BasePageBlock(models.Model):
         return self.pageblocks.first()
 
     def needs_submit(self):
+        """Determines whether this pageblock needs form controls rendered.
+
+        If needs_submit is True, then pagetree will create a <form>
+        on this pageblock's surrounding page, and a Submit button for
+        that form. It may also render a "Clear results" button, under
+        the right circumstances. The surrounding <form> allows pagetree
+        to handle form submissions for multiple blocks on the same page.
+
+        Also, when needs_submit is True, the POST data on the Section's
+        submit() step gets processed, but when needs_submit is False,
+        nothing is sent to the server.
+
+        :returns: a boolean
+        """
+
         return False
 
-    @classmethod
-    def add_form(cls):
+    def submit(self):
+        """Handle this pageblock's form submission.
+
+        :returns: None
+        """
+
+        pass
+
+    def unlocked(self, user):
+        """Determines whether the user can proceed past this block.
+
+        The current user is passed in to this function, allowing you to,
+        for example, find out if that user has submitted the info
+        necessary to proceed past this block's page.
+
+        :param user: the current user
+        :returns: a boolean
+        """
+
+        return True
+
+    @staticmethod
+    def add_form():
         return BasePageBlockForm()
 
     def edit_form(self):
         return BasePageBlockForm(instance=self)
 
-    @classmethod
-    def create(cls, request):
+    @staticmethod
+    def create(request):
         form = BasePageBlockForm(request.POST)
         return form.save()
 
@@ -41,9 +77,6 @@ class BasePageBlock(models.Model):
         form = BasePageBlockForm(data=vals, files=files, instance=self)
         if form.is_valid():
             form.save()
-
-    def unlocked(self, user):
-        return True
 
 
 class BasePageBlockForm(forms.ModelForm):

--- a/worth2/main/views.py
+++ b/worth2/main/views.py
@@ -170,6 +170,10 @@ class ParticipantSessionPageView(
                 'goal_checkin_context': self.goal_checkin_context,
             })
 
+        avatarselectorblock = self.get_first_block_of_type(
+            'avatar selector block')
+        ctx.update({'avatarselectorblock': avatarselectorblock})
+
         return ctx
 
     def get_context_data(self, **kwargs):
@@ -199,7 +203,7 @@ class ParticipantSessionPageView(
             pageblocks.filter(content_type__in=quiztypes)]
 
         # Was the form submitted with no values selected?
-        # TODO: move this logic to a RateMyRiskViewMixin.
+        # TODO: move this logic to a mixin.
         is_submission_empty = False
         for submission in quizblock.models.Submission.objects.filter(
                 user=request.user, quiz__in=quizblocks_on_this_page):

--- a/worth2/protectivebehaviors/models.py
+++ b/worth2/protectivebehaviors/models.py
@@ -1,32 +1,33 @@
 from django import forms
-from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 
-from pagetree.models import PageBlock
+from worth2.main.generic.models import BasePageBlock
 
 
-class ProtectiveBehaviorsResults(models.Model):
-    pageblocks = GenericRelation(PageBlock)
+class ProtectiveBehaviorsResults(BasePageBlock):
     quiz_class = models.CharField(max_length=255, help_text='Required',
                                   default='protective-behaviors')
     display_name = 'Protective Behaviors Results'
     template_file = 'protectivebehaviors/protective_behaviors_results.html'
 
-    def pageblock(self):
-        return self.pageblocks.first()
+    def needs_submit(self):
+        return False
+
+    def unlocked(self, user):
+        return True
 
     def __unicode__(self):
         return "%s -- %s" % (unicode(self.pageblock()), self.quiz_category)
 
-    @classmethod
-    def add_form(self):
+    @staticmethod
+    def add_form():
         return ProtectiveBehaviorsResultsForm()
 
     def edit_form(self):
         return ProtectiveBehaviorsResultsForm(instance=self)
 
-    @classmethod
-    def create(self, request):
+    @staticmethod
+    def create(request):
         form = ProtectiveBehaviorsResultsForm(request.POST)
         return form.save()
 
@@ -35,12 +36,6 @@ class ProtectiveBehaviorsResults(models.Model):
             data=vals, files=files, instance=self)
         if form.is_valid():
             form.save()
-
-    def needs_submit(self):
-        return False
-
-    def unlocked(self, user):
-        return True
 
 
 class ProtectiveBehaviorsResultsForm(forms.ModelForm):

--- a/worth2/ssnm/models.py
+++ b/worth2/ssnm/models.py
@@ -46,15 +46,15 @@ class SsnmPageBlock(BasePageBlock):
     js_template_file = 'ssnm/ssnm_js.html'
     css_template_file = 'ssnm/ssnm_css.html'
 
-    @classmethod
-    def add_form(cls):
+    @staticmethod
+    def add_form():
         return SsnmPageBlockForm()
 
     def edit_form(self):
         return SsnmPageBlockForm(instance=self)
 
-    @classmethod
-    def create(cls, request):
+    @staticmethod
+    def create(request):
         form = SsnmPageBlockForm(request.POST)
         return form.save()
 

--- a/worth2/templates/main/avatar_selector_block.html
+++ b/worth2/templates/main/avatar_selector_block.html
@@ -2,15 +2,13 @@
 <h2>Get Personal!</h2>
 
 <div class="worth-avatars">
-    <form method="post" action=".">{% csrf_token %}
-        {% for avatar in block.avatars %}
-        <span class="worth-avatar">
-            <img src="{{ avatar.image.url }}" />
-        </span>
-        <button class="btn btn-default" type="submit"
-                name="pageblock-{{block.pageblock.pk}}-avatar-id"
-                value="{{ avatar.pk }}"
-                >This is me!</button>
-        {% endfor %}
-    </form>
+    {% for avatar in block.avatars %}
+    <span class="worth-avatar">
+        <img src="{{ avatar.image.url }}" />
+    </span>
+    <button class="btn btn-default" type="submit"
+            name="pageblock-{{block.pageblock.pk}}-avatar-id"
+            value="{{ avatar.pk }}"
+            >This is me!</button>
+    {% endfor %}
 </div>

--- a/worth2/templates/pagetree/page.html
+++ b/worth2/templates/pagetree/page.html
@@ -1,5 +1,6 @@
 {% extends 'pagetree/base_pagetree.html' %}
 {% load render %}
+{% load user_status %}
 
 {% block js %}
 {% for block in section.pageblock_set.all %}
@@ -37,17 +38,18 @@
 {% endif %}
 {% endblock %}
 
-
 {% block sidenav %}
 {% endblock %}
 
 {% block content %}
+
+<script>
+    var isSectionUnlocked = {% is_section_unlocked section user %};
+</script>
+
 <div id="content">
-{% if needs_submit %}
-{% if is_submitted %}
-{% else %}
+{% if needs_submit and not is_submitted %}
 <form action="." method="post">{% csrf_token %}
-{% endif %}
 {% endif %}
 
 {% for block in section.pageblock_set.all %}
@@ -57,9 +59,7 @@
 </div>
 {% endfor %}
 
-{% if needs_submit %}
-{% if request.user.is_anonymous %}
-{% else %}
+{% if needs_submit and not request.user.is_anonymous %}
 
 {% if is_submission_empty %}
 <div class="clearfix"></div>
@@ -84,10 +84,15 @@
 
 <div class="clearfix"></div>
 
+{% comment %}
+The avatar selector block needs to hide the submit button, since
+each avatar has its own submit button.
+{% endcomment %}
+{% if not avatarselectorblock %}
 <input type="submit" value="Submit" class="btn btn-primary" />
+{% endif %}
 
 </form>
-{% endif %}
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
This adds pageblock gating for goal setting/checkin blocks and avatar selector block. There's also a lot of cleanup in this commit.

One outstanding issue here is my goal setting and checkin pages are rendering incorrectly when `unlocked` is `False`. However, when I click the 'submit' button without entering any data, the validation error appears as normal, and everything looks correct. Have you run into this problem before / know how to fix it?
![2015-02-27-121725_833x741_scrot](https://cloud.githubusercontent.com/assets/59292/6417604/7210331a-be7c-11e4-8191-2cc63b8a0049.png)

![2015-02-27-122621_818x603_scrot](https://cloud.githubusercontent.com/assets/59292/6417605/742e7a12-be7c-11e4-932c-de8482d806ef.png)
