### PR TITLE
Add responsive video embed from Marc - PMT #99807

### DIFF
--- a/media/css/video.css
+++ b/media/css/video.css
@@ -1,8 +1,2 @@
-/* Set .video-block width/height to match what's specified in
-   youtube-player.js, to prevent abrupt size changes on the page
-   as the video loads.
- */
 .video-block {
-    width: 640px;
-    height: 390px;
 }

--- a/worth2/templates/main/video_block.html
+++ b/worth2/templates/main/video_block.html
@@ -1,3 +1,6 @@
 <div class="video-block">
-    <div id="youtube-player"></div>
+    <div class="embed-responsive embed-responsive-16by9">
+        <!-- The youtube api turns this div into an iframe -->
+        <div id="youtube-player" class="embed-responsive-item"></div>
+    </div>
 </div>


### PR DESCRIPTION
This makes the youtube videos fill the whole width of the page.

http://getbootstrap.com/components/#responsive-embed