### PR TITLE
Prevent bootstrap from loading in the require.js app

### DIFF
--- a/media/js/src/app.js
+++ b/media/js/src/app.js
@@ -12,7 +12,6 @@ define([
     'views/goal-checkin-form',
     'views/gated-video',
     'views/unlocker',
-    'bootstrap',
     'jquery-cookie'
 ], function(
     $, _, Backbone,

--- a/media/js/src/main.js
+++ b/media/js/src/main.js
@@ -18,8 +18,7 @@ require.config({
         jquery: '../lib/jquery',
         'jquery-cookie': '../lib/jquery.cookie',
         underscore: '../lib/underscore',
-        backbone: '../lib/backbone',
-        bootstrap: '//netdna.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min'
+        backbone: '../lib/backbone'
     },
     urlArgs: 'bust=' + (new Date()).getTime()
 });

--- a/worth2/templates/base.html
+++ b/worth2/templates/base.html
@@ -142,5 +142,7 @@ You are impersonating.<br />
 <a class="btn" href="{% url 'impersonate-stop' %}">stop</a>
 </div>
 {% endif %}
+<script src="{{STATIC_URL}}js/lib/jquery.js"></script>
+{% bootstrap_javascript %}
 </body>
 </html>


### PR DESCRIPTION
I'm not using bootstrap's JS anywhere in worth's JS app,
and taking bootstrap out of require.js noticeably speeds up
js loading.