### PR TITLE
Differentiate internal/external selftalk in tests - PMT #98029

### DIFF
--- a/media/js/src/forms/selftalk-internalstatementform.js
+++ b/media/js/src/forms/selftalk-internalstatementform.js
@@ -1,0 +1,35 @@
+(function() {
+    /**
+     * refreshInputDisplay looks at each dropdown in the array
+     * '$dropdowns' and hides or shows the 'other' input if the
+     * appropriate dropdown option is selected.
+     *
+     * Params:
+     * $dropdowns - an array of <select> elements.
+     */
+    function refreshInputDisplay($dropdowns) {
+        $dropdowns.each(function(k, v) {
+            var $v = $(v);
+            var val = $v.val();
+            var selectedText = $.trim(
+                $v.find('option[value=' + val + ']').text());
+
+            var $otherInput = $v.closest('.form-group').next().find('input');
+            if (selectedText.toLowerCase() === 'other') {
+                $otherInput.show();
+            } else {
+                $otherInput.hide();
+            }
+        });
+    }
+
+    $(document).ready(function() {
+        var $el = $('#selftalk-statement-block');
+        var $dropdowns = $el.find('.statement-dropdown');
+
+        $dropdowns.on('change', function() {
+            refreshInputDisplay($dropdowns);
+        });
+        refreshInputDisplay($dropdowns);
+    });
+})();

--- a/worth2/selftalk/forms.py
+++ b/worth2/selftalk/forms.py
@@ -1,6 +1,15 @@
 from django import forms
 
 
+class InternalStatementForm(forms.Form):
+    class Media:
+        extend = False
+        css = {
+            'all': ('/media/css/selftalk-internalstatementform.css',)
+        }
+        js = ('/media/js/src/forms/selftalk-internalstatementform.js',)
+
+
 class RefutationForm(forms.Form):
     class Media:
         extend = False

--- a/worth2/selftalk/mixins.py
+++ b/worth2/selftalk/mixins.py
@@ -15,16 +15,42 @@ class SelfTalkStatementViewMixin(object):
         :returns: a class
         """
 
-        class DynamicStatementForm(forms.Form):
+        class DynamicExternalStatementForm(forms.Form):
             def __init__(self, *args, **kwargs):
-                super(DynamicStatementForm, self).__init__(
+                super(DynamicExternalStatementForm, self).__init__(
                     *args, **kwargs)
                 for statement in statementblock.block().statements.all():
                     self.fields['%d' % statement.pk] = forms.BooleanField(
                         label='"' + statement.text + '"',
                         required=False)
 
-        return DynamicStatementForm
+        # TODO: waiting on spec for this form, PMT #98029
+        class DynamicInternalStatementForm(forms.Form):
+            statement1 = forms.ModelChoiceField(
+                widget=forms.Select(
+                    attrs={'class': 'statement-dropdown'}),
+                label="My Negative Thing",
+                queryset=statementblock.block().statements.all(),
+                empty_label="Select")
+            statement1_other = forms.CharField(
+                label="Other", required=False)
+            statement2 = forms.ModelChoiceField(
+                widget=forms.Select(
+                    attrs={'class': 'statement-dropdown'}),
+                label="My Negative Thing",
+                queryset=statementblock.block().statements.all(),
+                empty_label="Select")
+            statement3 = forms.ModelChoiceField(
+                widget=forms.Select(
+                    attrs={'class': 'statement-dropdown'}),
+                label="My Negative Thing",
+                queryset=statementblock.block().statements.all(),
+                empty_label="Select")
+
+        if statementblock.block().is_internal:
+            return DynamicInternalStatementForm
+        else:
+            return DynamicExternalStatementForm
 
     def create_selftalk_statement_form(self, request, statementblock):
         initial_data = {}

--- a/worth2/selftalk/tests/test_views.py
+++ b/worth2/selftalk/tests/test_views.py
@@ -8,9 +8,9 @@ from worth2.selftalk.tests.factories import (
 from worth2.selftalk.models import StatementResponse, RefutationResponse
 
 
-class StatementBlockTest(LoggedInParticipantTestMixin, TestCase):
+class ExternalStatementBlockTest(LoggedInParticipantTestMixin, TestCase):
     def setUp(self):
-        super(StatementBlockTest, self).setUp()
+        super(ExternalStatementBlockTest, self).setUp()
 
         self.h = get_hierarchy('main', '/pages/')
         self.root = self.h.get_root()
@@ -20,6 +20,7 @@ class StatementBlockTest(LoggedInParticipantTestMixin, TestCase):
             'slug': 'statement',
             'pageblocks': [{
                 'block_type': 'Self-Talk Negative Statement Block',
+                'is_internal': False,
             }],
             'children': [],
         })
@@ -74,9 +75,9 @@ class StatementBlockTest(LoggedInParticipantTestMixin, TestCase):
         self.assertEqual(responses.count(), 2)
 
 
-class RefutationBlockTest(LoggedInParticipantTestMixin, TestCase):
+class ExternalRefutationBlockTest(LoggedInParticipantTestMixin, TestCase):
     def setUp(self):
-        super(RefutationBlockTest, self).setUp()
+        super(ExternalRefutationBlockTest, self).setUp()
 
         self.h = get_hierarchy('main', '/pages/')
         self.root = self.h.get_root()
@@ -86,6 +87,7 @@ class RefutationBlockTest(LoggedInParticipantTestMixin, TestCase):
             'slug': 'statement',
             'pageblocks': [{
                 'block_type': 'Self-Talk Negative Statement Block',
+                'is_internal': False,
             }],
             'children': [],
         })


### PR DESCRIPTION
This cleans up the selftalk tests to make it clear whether it's testing
and 'internal' or 'external' scenario. Also includes some changes to the
internal negative statement setting form, which will be implemented once
the spec for this form solidifies (PMT #98029).