### PR TITLE
Show a different view if the avatar selector has been submitted

### DIFF
--- a/worth2/main/models.py
+++ b/worth2/main/models.py
@@ -93,6 +93,11 @@ class AvatarSelectorBlock(BasePageBlock):
             user.profile.participant.avatar = avatar
             user.profile.participant.save()
 
+    def clear_user_submissions(self, user):
+        if user_is_participant(user):
+            user.profile.participant.avatar = None
+            user.profile.participant.save()
+
     def avatars(self):
         """Returns a queryset of all the available avatars in WORTH."""
 

--- a/worth2/templates/main/avatar_selector_block.html
+++ b/worth2/templates/main/avatar_selector_block.html
@@ -1,14 +1,23 @@
+{% load avatar %}
+
 <h1>My Avatar</h1>
 <h2>Get Personal!</h2>
 
 <div class="worth-avatars">
+    {% if is_submitted %}
+    <div>Here's the avatar you selected:</div>
+    <div class="worth-avatar">
+        <img class="thumbnail" src="{% avatar_url user %}">
+    </div>
+    {% else %}
     {% for avatar in block.avatars %}
     <span class="worth-avatar">
-        <img src="{{ avatar.image.url }}" />
+        <img class="media" src="{{ avatar.image.url }}">
     </span>
     <button class="btn btn-default" type="submit"
             name="pageblock-{{block.pageblock.pk}}-avatar-id"
             value="{{ avatar.pk }}"
             >This is me!</button>
     {% endfor %}
+    {% endif %}
 </div>


### PR DESCRIPTION
Instead of displaying a non-functional form when the avatar is selected,
make it clear that one is already chosen.