### PR TITLE
Associate goal options with goal type instead of pageblock - PMT #98022

### DIFF
--- a/worth2/goals/admin.py
+++ b/worth2/goals/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from ordered_model.admin import OrderedModelAdmin
 
-from worth2.goals.models import GoalSettingBlock, GoalCheckInOption, GoalOption
+from worth2.goals.models import GoalCheckInOption, GoalOption
 
 
 class GoalCheckInOptionAdmin(OrderedModelAdmin):
@@ -10,18 +10,9 @@ class GoalCheckInOptionAdmin(OrderedModelAdmin):
 
 
 class GoalOptionAdmin(OrderedModelAdmin):
-    list_display = ('text', 'move_up_down_links')
+    list_display = ('text', 'goal_type', 'move_up_down_links')
     model = GoalOption
-
-
-class GoalOptionInline(admin.TabularInline):
-    model = GoalOption
-
-
-class GoalSettingBlockAdmin(admin.ModelAdmin):
-    inlines = [GoalOptionInline]
 
 
 admin.site.register(GoalCheckInOption, GoalCheckInOptionAdmin)
 admin.site.register(GoalOption, GoalOptionAdmin)
-admin.site.register(GoalSettingBlock, GoalSettingBlockAdmin)

--- a/worth2/goals/migrations/0017_auto_20150312_0940.py
+++ b/worth2/goals/migrations/0017_auto_20150312_0940.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('goals', '0016_auto_20150227_1224'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='goaloption',
+            name='goal_setting_block',
+        ),
+        migrations.AddField(
+            model_name='goaloption',
+            name='goal_type',
+            field=models.CharField(default=b'services', max_length=255, db_index=True, choices=[(b'services', b'Services'), (b'risk reduction', b'Risk Reduction'), (b'social support', b'Social Support')]),
+            preserve_default=True,
+        ),
+    ]

--- a/worth2/goals/mixins.py
+++ b/worth2/goals/mixins.py
@@ -108,7 +108,7 @@ class GoalSettingViewMixin(object):
             option = forms.ModelChoiceField(
                 label='Main services goal',
                 queryset=GoalOption.objects.filter(
-                    goal_setting_block=goalsettingblock.block()),
+                    goal_type=goalsettingblock.block().goal_type),
                 widget=forms.Select(
                     attrs={'class': 'form-control goal-option'}),
             )

--- a/worth2/goals/models.py
+++ b/worth2/goals/models.py
@@ -6,6 +6,13 @@ from ordered_model.models import OrderedModel
 from worth2.main.generic.models import BasePageBlock
 
 
+GOAL_TYPES = (
+    ('services', 'Services'),
+    ('risk reduction', 'Risk Reduction'),
+    ('social support', 'Social Support'),
+)
+
+
 class GoalSettingBlock(BasePageBlock):
     """A PageBlock for allowing participants to set goals.
 
@@ -22,10 +29,7 @@ class GoalSettingBlock(BasePageBlock):
 
     goal_type = models.CharField(
         max_length=255,
-        choices=(
-            ('services', 'Services'),
-            ('risk reduction', 'Risk Reduction'),
-            ('social support', 'Social Support')),
+        choices=GOAL_TYPES,
         default='services',
     )
 
@@ -90,9 +94,18 @@ class GoalSettingBlockForm(forms.ModelForm):
 
 
 class GoalOption(OrderedModel):
-    """GoalSettingBlock dropdowns are populated by GoalOptions."""
+    """GoalSettingBlock dropdowns are populated by GoalOptions.
 
-    goal_setting_block = models.ForeignKey(GoalSettingBlock)
+    The contents of each GoalSettingBlock's dropdown depends on its
+    goal_type.
+    """
+
+    goal_type = models.CharField(
+        max_length=255,
+        choices=GOAL_TYPES,
+        default='services',
+        db_index=True,
+    )
     text = models.TextField(
         help_text='An option for the dropdowns in a specific ' +
         'GoalSetting pageblock.')

--- a/worth2/goals/tests/factories.py
+++ b/worth2/goals/tests/factories.py
@@ -19,7 +19,6 @@ class GoalOptionFactory(factory.DjangoModelFactory):
     class Meta:
         model = GoalOption
 
-    goal_setting_block = factory.SubFactory(GoalSettingBlockFactory)
     text = FuzzyText()
 
 

--- a/worth2/goals/tests/test_views.py
+++ b/worth2/goals/tests/test_views.py
@@ -53,15 +53,12 @@ class GoalCheckInBlockTest(LoggedInParticipantTestMixin, TestCase):
 
         self.url = '/pages/goal-check-in-section/'
 
-        opt1 = GoalOptionFactory(goal_setting_block=goalsettingblock.block())
-        opt2 = GoalOptionFactory(goal_setting_block=goalsettingblock.block())
-        opt3 = GoalOptionFactory(goal_setting_block=goalsettingblock.block())
+        opt1 = GoalOptionFactory()
+        opt2 = GoalOptionFactory()
+        opt3 = GoalOptionFactory()
 
         # This option will be hidden from the check-in formset
-        opt4_na = GoalOptionFactory(
-            text='n/a',
-            goal_setting_block=goalsettingblock.block(),
-        )
+        opt4_na = GoalOptionFactory(text='n/a')
         self.assertEqual(GoalSettingBlock.objects.count(), 1)
 
         self.setting_resp1 = GoalSettingResponseFactory(
@@ -364,7 +361,7 @@ class GoalSettingBlockTest(LoggedInParticipantTestMixin, TestCase):
 
     def test_post(self):
         pageblock = self.root.get_first_child().pageblock_set.first()
-        option = GoalOptionFactory(goal_setting_block=pageblock.block())
+        option = GoalOptionFactory()
         p = 'pageblock-%s' % pageblock.pk
         r = self.client.post(self.url, {
             # Formset Management form params
@@ -399,7 +396,7 @@ class GoalSettingBlockTest(LoggedInParticipantTestMixin, TestCase):
         """Assert that a submission with only the Main form populated works."""
 
         pageblock = self.root.get_first_child().pageblock_set.first()
-        option = GoalOptionFactory(goal_setting_block=pageblock.block())
+        option = GoalOptionFactory()
         p = 'pageblock-%s' % pageblock.pk
         r = self.client.post(self.url, {
             # Formset Management form params
@@ -430,8 +427,8 @@ class GoalSettingBlockTest(LoggedInParticipantTestMixin, TestCase):
         """
 
         pageblock = self.root.get_first_child().pageblock_set.first()
-        option = GoalOptionFactory(goal_setting_block=pageblock.block())
-        option2 = GoalOptionFactory(goal_setting_block=pageblock.block())
+        option = GoalOptionFactory()
+        option2 = GoalOptionFactory()
 
         p = 'pageblock-%s' % pageblock.pk
         self.client.post(self.url, {
@@ -490,7 +487,7 @@ class GoalSettingBlockTest(LoggedInParticipantTestMixin, TestCase):
 
     def test_post_invalid(self):
         pageblock = self.root.get_first_child().pageblock_set.first()
-        GoalOptionFactory(goal_setting_block=pageblock.block())
+        GoalOptionFactory()
         p = 'pageblock-%s' % pageblock.pk
         r = self.client.post(self.url, {
             # Formset Management form params
@@ -517,9 +514,8 @@ class GoalSettingBlockTest(LoggedInParticipantTestMixin, TestCase):
 
     def test_post_na_option_makes_text_not_required(self):
         pageblock = self.root.get_first_child().pageblock_set.first()
-        GoalOptionFactory(goal_setting_block=pageblock.block())
-        na_option = GoalOptionFactory(
-            text='n/a', goal_setting_block=pageblock.block())
+        GoalOptionFactory()
+        na_option = GoalOptionFactory(text='n/a')
         p = 'pageblock-%s' % pageblock.pk
         r = self.client.post(self.url, {
             # Formset Management form params
@@ -540,9 +536,8 @@ class GoalSettingBlockTest(LoggedInParticipantTestMixin, TestCase):
 
     def test_post_other_option_makes_other_text_required(self):
         pageblock = self.root.get_first_child().pageblock_set.first()
-        GoalOptionFactory(goal_setting_block=pageblock.block())
-        other_option = GoalOptionFactory(
-            text='Other', goal_setting_block=pageblock.block())
+        GoalOptionFactory()
+        other_option = GoalOptionFactory(text='Other')
         p = 'pageblock-%s' % pageblock.pk
         r = self.client.post(self.url, {
             # Formset Management form params
@@ -565,9 +560,8 @@ class GoalSettingBlockTest(LoggedInParticipantTestMixin, TestCase):
 
     def test_post_valid_with_other_option(self):
         pageblock = self.root.get_first_child().pageblock_set.first()
-        GoalOptionFactory(goal_setting_block=pageblock.block())
-        other_option = GoalOptionFactory(
-            text='Other', goal_setting_block=pageblock.block())
+        GoalOptionFactory()
+        other_option = GoalOptionFactory(text='Other')
         p = 'pageblock-%s' % pageblock.pk
         r = self.client.post(self.url, {
             # Formset Management form params

--- a/worth2/templates/goals/goal_check_in_block.html
+++ b/worth2/templates/goals/goal_check_in_block.html
@@ -13,7 +13,7 @@
     <div class="row">
     
     <div class="col-sm-8">
-        <form class="form-horizontal" method="post">
+        <div class="form-horizontal">
         
         {% csrf_token %}
         {{ checkin_formset.management_form }}
@@ -61,11 +61,8 @@
         {% endfor %}
             <div class="clearfix"></div>
             <hr />
-        <div class="form-group">
-                <button type="submit" class="btn btn-primary">Submit</button>
-        </div>
         
-    </form>
+    </div><!-- end .form-horizontal -->
     </div>
     
     <div class="col-sm-4 avatar-block">

--- a/worth2/templates/goals/goal_setting_block.html
+++ b/worth2/templates/goals/goal_setting_block.html
@@ -11,7 +11,7 @@
     <div class="row">
     
         <div class="col-sm-10">
-            <form class="form-horizontal" method="post">
+            <div class="form-horizontal">
             {% csrf_token %}
             {{ setting_formset.management_form }}
             {% if messages %}
@@ -51,14 +51,7 @@
             <div class="clearfix"></div>
             {% endif %}
             {% endfor %}
-            <div class="clearfix"></div>
-            <div class="form-group">
-                <label class="col-sm-2 control-label"></label>
-                <div class="col-sm-4">
-                    <button type="submit" class="btn btn-primary">Submit</button>
-                </div>
-            </div>
-            </form>
+            </div><!-- end .form-horizontal -->
         </div>
 
         <div class="col-sm-2 avatar-block">


### PR DESCRIPTION
The spec for these goal options changed slightly. Each goal type has
the same set of goal options, so the goal options should be associated
with goal type instead of the specific goal-setting pageblock.

Also:
* Get rid of extra submit button in goal setting/checkin blocks