### PR TITLE
Use s3 instead of cloudfront, for CORS compatibility

### DIFF
--- a/worth2/settings_production.py
+++ b/worth2/settings_production.py
@@ -22,13 +22,12 @@ DATABASES = {
 
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG
-AWS_S3_CUSTOM_DOMAIN = 'd1tpq2w6jljbie.cloudfront.net'
 AWS_STORAGE_BUCKET_NAME = "ccnmtl-worth2-static-prod"
 AWS_PRELOAD_METADATA = True
 DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 STATICFILES_STORAGE = 'worth2.s3utils.CompressorS3BotoStorage'
-S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
-STATIC_URL = 'https://%s/media/' % AWS_S3_CUSTOM_DOMAIN
+S3_URL = 'https://%s.s3.amazonaws.com/' % AWS_STORAGE_BUCKET_NAME
+STATIC_URL = 'https://%s.s3.amazonaws.com/media/' % AWS_STORAGE_BUCKET_NAME
 COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = True
 COMPRESS_ROOT = STATIC_ROOT

--- a/worth2/settings_staging.py
+++ b/worth2/settings_staging.py
@@ -24,13 +24,12 @@ DEBUG = False
 TEMPLATE_DEBUG = True
 STAGING_ENV = True
 
-AWS_S3_CUSTOM_DOMAIN = 'd1t432giinsu9y.cloudfront.net'
 AWS_STORAGE_BUCKET_NAME = "ccnmtl-worth2-static-stage"
 AWS_PRELOAD_METADATA = True
 DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 STATICFILES_STORAGE = 'worth2.s3utils.CompressorS3BotoStorage'
-S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
-STATIC_URL = 'https://%s/media/' % AWS_S3_CUSTOM_DOMAIN
+S3_URL = 'https://%s.s3.amazonaws.com/' % AWS_STORAGE_BUCKET_NAME
+STATIC_URL = 'https://%s.s3.amazonaws.com/media/' % AWS_STORAGE_BUCKET_NAME
 COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = True
 COMPRESS_ROOT = STATIC_ROOT


### PR DESCRIPTION
I can't figure out how to get cloudfront to respond with cors headers,
and it's holding up development because I need Jess to review the self-talk
activity, so I'm reverting to S3.

I'm not even sure if cloudfront supports CORS or not right now, in
the past at least, it wasn't supported:
https://forums.aws.amazon.com/message.jspa?messageID=512173#512173