### PR TITLE
Revert to S3 for now instead of cloudfront

### DIFF
--- a/worth2/settings_production.py
+++ b/worth2/settings_production.py
@@ -22,13 +22,12 @@ DATABASES = {
 
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG
-AWS_S3_CUSTOM_DOMAIN = 'd1tpq2w6jljbie.cloudfront.net'
 AWS_STORAGE_BUCKET_NAME = "ccnmtl-worth2-static-prod"
 AWS_PRELOAD_METADATA = True
 DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 STATICFILES_STORAGE = 'worth2.s3utils.CompressorS3BotoStorage'
-S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
-STATIC_URL = 'https://%s/media/' % AWS_S3_CUSTOM_DOMAIN
+S3_URL = 'https://%s.s3.amazonaws.com/' % AWS_STORAGE_BUCKET_NAME
+STATIC_URL = 'https://%s.s3.amazonaws.com/media/' % AWS_STORAGE_BUCKET_NAME
 COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = True
 COMPRESS_ROOT = STATIC_ROOT

--- a/worth2/settings_staging.py
+++ b/worth2/settings_staging.py
@@ -24,13 +24,12 @@ DEBUG = False
 TEMPLATE_DEBUG = True
 STAGING_ENV = True
 
-AWS_S3_CUSTOM_DOMAIN = 'd1t432giinsu9y.cloudfront.net'
 AWS_STORAGE_BUCKET_NAME = "ccnmtl-worth2-static-stage"
 AWS_PRELOAD_METADATA = True
 DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 STATICFILES_STORAGE = 'worth2.s3utils.CompressorS3BotoStorage'
-S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
-STATIC_URL = 'https://%s/media/' % AWS_S3_CUSTOM_DOMAIN
+S3_URL = 'https://%s.s3.amazonaws.com/' % AWS_STORAGE_BUCKET_NAME
+STATIC_URL = 'https://%s.s3.amazonaws.com/media/' % AWS_STORAGE_BUCKET_NAME
 COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = True
 COMPRESS_ROOT = STATIC_ROOT


### PR DESCRIPTION
I'd like to make sure we have CORS headers working properly on
S3, and then switch to cloudfront once we figure it out.