### PR TITLE
Fix some problems with inconsistent form behavior on selftalk forms

### DIFF
--- a/worth2/main/views.py
+++ b/worth2/main/views.py
@@ -198,9 +198,15 @@ class ParticipantSessionPageView(
         return ctx
 
     def get_context_data(self, **kwargs):
+        allow_redo = False
+        needs_submit = self.section.needs_submit()
+        if needs_submit:
+            allow_redo = self.section.allow_redo()
         context = dict(
             section=self.section,
             module=self.module,
+            needs_submit=needs_submit,
+            allow_redo=allow_redo,
             is_submitted=self.section.submitted(self.request.user),
             modules=self.root.get_children(),
             root=self.section.hierarchy.get_root(),
@@ -209,22 +215,15 @@ class ParticipantSessionPageView(
         return context
 
     def get(self, request, *args, **kwargs):
-        allow_redo = False
-        needs_submit = self.section.needs_submit()
-        if needs_submit:
-            allow_redo = self.section.allow_redo()
+        context = self.get_context_data(**kwargs)
         self.upv.visit()
         instructor_link = has_responses(self.section)
 
         # This flag is always False on non-protective behaviors quizzes.
         is_submission_empty = remove_empty_submission(request.user,
                                                       self.section)
-
-        context = self.get_context_data(**kwargs)
         context.update({
-            'allow_redo': allow_redo,
             'is_submission_empty': is_submission_empty,
-            'needs_submit': needs_submit,
             'instructor_link': instructor_link,
         })
         return render(request, self.template_name, context)

--- a/worth2/selftalk/models.py
+++ b/worth2/selftalk/models.py
@@ -46,9 +46,12 @@ class StatementBlock(BasePageBlock):
     user themselves. "External" indicates that this is a scenario based
     around a video, rather than a self-reflective excercise.
 
-    If this block is "external", it gives the participant a list of
-    statements to check off what they remember hearing in the video they
-    just watched.
+    This block gives the participant a list of statements to check off
+    either:
+      * What they remember hearing in the video they just watched. (If
+        is_internal is False).
+      * Or, what negative statements they might say to themselves (If
+        is_internal is True).
 
     The statements the participant chooses will populate the fields in
     the next page, which will be a RefutationBlock.

--- a/worth2/templates/pagetree/page.html
+++ b/worth2/templates/pagetree/page.html
@@ -61,7 +61,6 @@
     {% endfor %}
 
 {% if needs_submit and not request.user.is_anonymous %}
-
 <div class="clearfix"></div>
 <div class="alert alert-danger worth-form-validation-error"
      role="alert"

--- a/worth2/templates/selftalk/statement_block.html
+++ b/worth2/templates/selftalk/statement_block.html
@@ -2,19 +2,10 @@
 
 <div class="selftalk-statement {{ block.css_class }}"
      id="selftalk-statement-block">
-    <h1>
-        {% if block.is_internal %}
-        My Self Talk
-        {% else %}
-        {{ block.subject_name }}'s Self Talk
-        {% endif %}
-    </h1>
-
     <p>
         {% if block.is_internal %}
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-        sed do eiusmod tempor incididunt ut labore et dolore magna
-        aliqua.
+        Imagine some negative things that you might say to yourself
+        in the coming week.
         {% else %}
         Do you remember what {{ block.subject_name }} said?
         {% endif %}


### PR DESCRIPTION
I fixed the issues by setting all the influential context variables
in PageView's get_context_data().