### PR TITLE
Try cloudfront again

### DIFF
--- a/worth2/settings_production.py
+++ b/worth2/settings_production.py
@@ -20,14 +20,14 @@ DATABASES = {
 
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG
-
+AWS_S3_CUSTOM_DOMAIN = 'd1tpq2w6jljbie.cloudfront.net'
 AWS_STORAGE_BUCKET_NAME = "ccnmtl-worth2-static-prod"
 AWS_PRELOAD_METADATA = True
 DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
-S3_URL = 'https://%s.s3.amazonaws.com/' % AWS_STORAGE_BUCKET_NAME
+S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
 STATIC_ROOT = '/tmp/worth2/static'
 STATICFILES_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
-STATIC_URL = 'https://%s.s3.amazonaws.com/media/' % AWS_STORAGE_BUCKET_NAME
+STATIC_URL = 'https://%s/media/' % AWS_S3_CUSTOM_DOMAIN
 COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = True
 COMPRESS_ROOT = STATIC_ROOT

--- a/worth2/settings_staging.py
+++ b/worth2/settings_staging.py
@@ -21,14 +21,14 @@ DATABASES = {
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 STAGING_ENV = True
-
+AWS_S3_CUSTOM_DOMAIN = 'd1t432giinsu9y.cloudfront.net'
 AWS_STORAGE_BUCKET_NAME = "ccnmtl-worth2-static-stage"
 AWS_PRELOAD_METADATA = True
 DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
-S3_URL = 'https://%s.s3.amazonaws.com/' % AWS_STORAGE_BUCKET_NAME
+S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
 STATIC_ROOT = '/tmp/worth2/static'
 STATICFILES_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
-STATIC_URL = 'https://%s.s3.amazonaws.com/media/' % AWS_STORAGE_BUCKET_NAME
+STATIC_URL = 'https://%s/media/' % AWS_S3_CUSTOM_DOMAIN
 COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = True
 COMPRESS_ROOT = STATIC_ROOT


### PR DESCRIPTION
Now that I've got the CORS issue with my three.js scene sorted
out on S3, I'll try using cloudfront again. The worth2 cloudfront
distributions are already set up to forward the necessary headers.