### PR TITLE
Fix session/module numbers - PMT #100689

### DIFF
--- a/worth2/goals/models.py
+++ b/worth2/goals/models.py
@@ -7,6 +7,8 @@ from ordered_model.models import OrderedModel
 from pagetree.generic.models import BasePageBlock
 from pagetree.reports import ReportColumnInterface, ReportableInterface
 
+from worth2.main.utils import get_module_number
+
 
 GOAL_TYPES = (
     ('services', 'Services'),
@@ -59,14 +61,11 @@ class GoalSettingBlock(BasePageBlock):
         return c > 0
 
     def __unicode__(self):
-        try:
-            slug = unicode(self.pageblock().section.get_parent().slug)
-        except AttributeError:
-            slug = 'no section'
-
-        return unicode(self.get_goal_type_display() + ' goals ' +
-                       '[' + slug + '] id: ' +
-                       unicode(self.pk))
+        session_num = get_module_number(self.pageblock())
+        return unicode('%s goals [Session %d] id: %d' % (
+            self.get_goal_type_display(),
+            session_num,
+            self.pk))
 
     @staticmethod
     def add_form():

--- a/worth2/main/generic/models.py
+++ b/worth2/main/generic/models.py
@@ -2,6 +2,7 @@ from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.db import models
 from pagetree.models import Hierarchy, UserPageVisit
+from worth2.main.utils import get_verbose_section_name
 
 
 class BaseUserProfile(models.Model):
@@ -57,21 +58,11 @@ class BaseUserProfile(models.Model):
         else:
             return upv.first().section
 
-    @staticmethod
-    def verbose_section_name(section):
-        """Returns a string."""
-
-        s = unicode(section)
-        if hasattr(section, 'slug') and section.slug:
-            s += " (%s)" % section.slug
-
-        return s
-
     def last_location_verbose(self):
-        return self.verbose_section_name(self.last_location())
+        return get_verbose_section_name(self.last_location())
 
     def next_location_verbose(self):
-        return self.verbose_section_name(self.last_location().get_next())
+        return get_verbose_section_name(self.last_location().get_next())
 
     def percent_complete(self):
         return self.percent_complete_hierarchy()

--- a/worth2/main/tests/test_models.py
+++ b/worth2/main/tests/test_models.py
@@ -9,6 +9,7 @@ from worth2.main.tests.factories import (
     AvatarFactory, EncounterFactory, LocationFactory, ParticipantFactory,
     VideoBlockFactory, WatchedVideoFactory
 )
+from worth2.main.utils import get_verbose_section_name
 
 
 class AvatarTest(TestCase):
@@ -63,8 +64,8 @@ class ParticipantTest(TestCase):
         r = self.participant.last_session_accessed(
             '/pages/session-1/some-activity')
         self.assertEqual(r, 1)
-        r = self.participant.last_session_accessed(
-            '/pages/session-1/')
+
+        r = self.participant.last_session_accessed('/pages/session-1/')
         self.assertEqual(r, 1)
 
         r = self.participant.last_session_accessed(
@@ -72,8 +73,7 @@ class ParticipantTest(TestCase):
         self.assertEqual(r, 5)
 
     def test_verbose_section_name(self):
-        s = self.participant.verbose_section_name(
-            self.participant.last_location())
+        s = get_verbose_section_name(self.participant.last_location())
         self.assertEqual(s, 'Root')
 
     def test_last_location_verbose(self):
@@ -82,7 +82,7 @@ class ParticipantTest(TestCase):
 
     def test_next_location_verbose(self):
         s = self.participant.next_location_verbose()
-        self.assertEqual(s, 'One (one)')
+        self.assertEqual(s, 'One')
 
 
 class ParticipantManagerTest(TestCase):

--- a/worth2/main/tests/test_utils.py
+++ b/worth2/main/tests/test_utils.py
@@ -1,11 +1,14 @@
 from django.test import TestCase
 from pagetree.helpers import get_hierarchy
 
-from worth2.main.utils import get_first_block_in_session
+from worth2.main.utils import (
+    get_first_block_in_module, get_module_number,
+    get_module_number_from_section, get_verbose_section_name
+)
 
 
 class UtilsTest(TestCase):
-    def test_get_first_block_in_session(self):
+    def setUp(self):
         h = get_hierarchy('main', '/pages/')
         root = h.get_root()
         root.add_child_section_from_dict({
@@ -29,20 +32,46 @@ class UtilsTest(TestCase):
             }],
         })
 
-        block = get_first_block_in_session('goal setting block', 1)
+    def test_get_first_block_in_module(self):
+        block = get_first_block_in_module('goal setting block', 1)
         self.assertEqual(block, None)
 
-        block = get_first_block_in_session('goal setting block', 2)
+        block = get_first_block_in_module('goal setting block', 2)
         self.assertEqual(block.section.slug, 'goal-setting')
 
-        block = get_first_block_in_session(
+        block = get_first_block_in_module(
             'goal setting block', 2,
             lambda (b): b.block().goal_type == 'services'
         )
         self.assertEqual(block.section.slug, 'goal-setting')
 
-        block = get_first_block_in_session(
+        block = get_first_block_in_module(
             'goal setting block', 2,
             lambda (b): b.block().goal_type == 'risk reduction'
         )
         self.assertEqual(block, None)
+
+    def test_get_module_number(self):
+        avatarblock = get_first_block_in_module('avatar selector block', 1)
+        self.assertEqual(get_module_number(avatarblock), 1)
+        goalsettingblock = get_first_block_in_module('goal setting block', 2)
+        self.assertEqual(get_module_number(goalsettingblock), 2)
+
+    def test_get_module_number_from_section(self):
+        avatarblock = get_first_block_in_module('avatar selector block', 1)
+        self.assertEqual(get_module_number_from_section(
+            avatarblock.section), 1)
+        goalsettingblock = get_first_block_in_module('goal setting block', 2)
+        self.assertEqual(get_module_number_from_section(
+            goalsettingblock.section), 2)
+
+    def test_get_verbose_section_name(self):
+        avatarblock = get_first_block_in_module('avatar selector block', 1)
+        self.assertEqual(
+            get_verbose_section_name(avatarblock.section).lower(),
+            'Session 1 [Session 1]'.lower())
+
+        goalsettingblock = get_first_block_in_module('goal setting block', 2)
+        self.assertEqual(
+            get_verbose_section_name(goalsettingblock.section).lower(),
+            'Goal Setting Block page [Session 2]'.lower())

--- a/worth2/main/tests/test_views.py
+++ b/worth2/main/tests/test_views.py
@@ -13,7 +13,7 @@ from worth2.main.tests.mixins import (
     LoggedInSuperuserTestMixin
 )
 from worth2.main.models import Encounter, Participant
-from worth2.main.utils import get_first_block_in_session
+from worth2.main.utils import get_first_block_in_module
 from worth2.main.views import ParticipantJournalView
 
 
@@ -290,7 +290,7 @@ class ParticipantJournalsTest(LoggedInFacilitatorTestMixin, TestCase):
             })
 
     def test_render_goals(self):
-        goalsettingblock = get_first_block_in_session(
+        goalsettingblock = get_first_block_in_module(
             'goal setting block', 1)
 
         option = GoalOption.objects.create(text='test option')

--- a/worth2/main/utils.py
+++ b/worth2/main/utils.py
@@ -1,8 +1,10 @@
+import re
 from django.contrib.contenttypes.models import ContentType
+from django.utils.encoding import smart_str
 from pagetree.models import Section
 
 
-def get_first_block_in_session(content_type, session_num, blocktest=None):
+def get_first_block_in_module(content_type, session_num, blocktest=None):
     """Returns the first block of given type in the given session.
 
     :param content_type: The pageblock ContentType, e.g. 'goal
@@ -63,3 +65,57 @@ def get_first_block_of_type(section, blocktype, blocktest=None):
             return None
     else:
         return pageblocks.first()
+
+
+def get_module_number_from_section(section):
+    """Returns the module number that the given section is in.
+
+    When no module is found, this function returns -1.
+
+    :rtype: int
+    """
+    if section.depth == 1:
+        # This is the 'Root' section, so there's no module associated
+        # with it.
+        return -1
+    elif section.depth == 2:
+        # depth == 2 is the expected depth for modules.
+        module_section = section
+    else:
+        # Find closest parent whose depth == 2
+        module_section = section
+        while module_section.depth > 2:
+            module_section = module_section.get_parent()
+
+    n = -1
+    match = re.match(r'session-(\d)', module_section.slug)
+    if match:
+        n = int(match.groups()[0])
+
+    return n
+
+
+def get_module_number(pageblock):
+    """Returns the module number that the given pageblock is in.
+
+    When no module is found, this function returns -1.
+
+    :rtype: int
+    """
+    if pageblock is None:
+        return -1
+
+    return get_module_number_from_section(pageblock.section)
+
+
+def get_verbose_section_name(section):
+    """Returns a string."""
+
+    s = smart_str(section)
+    module_num = get_module_number_from_section(section)
+
+    # Only append the module number if it's valid.
+    if module_num > -1:
+        return smart_str('%s [Session %d]' % (s, module_num))
+    else:
+        return s

--- a/worth2/main/views.py
+++ b/worth2/main/views.py
@@ -23,7 +23,7 @@ from worth2.main.forms import SignInParticipantForm
 from worth2.main.models import Encounter, Participant, Location
 from worth2.main.reports import ParticipantReport
 from worth2.main.utils import (
-    get_first_block_in_session, get_first_block_of_type
+    get_first_block_in_module, get_first_block_of_type
 )
 from worth2.protectivebehaviors.utils import remove_empty_submission
 from worth2.selftalk.mixins import (
@@ -134,7 +134,7 @@ class ParticipantJournalView(TemplateView):
         ]
 
         # Find the first 'services' type goal setter in Session 1
-        goalsettingblock = get_first_block_in_session(
+        goalsettingblock = get_first_block_in_module(
             'goal setting block', 1,
             lambda (b): b.block().goal_type == 'services')
 
@@ -211,7 +211,7 @@ class ParticipantJournalView(TemplateView):
         ]
 
         # Find the first 'risk reduction' goal setter in Session 2
-        risk_goalsettingblock = get_first_block_in_session(
+        risk_goalsettingblock = get_first_block_in_module(
             'goal setting block', 2,
             lambda (b): b.block().goal_type == 'risk reduction')
 
@@ -219,7 +219,7 @@ class ParticipantJournalView(TemplateView):
         info.append(self._render_goals(risk_goalsettingblock, user))
 
         # Find the first 'services' goal setter in Session 2
-        services_goalsettingblock = get_first_block_in_session(
+        services_goalsettingblock = get_first_block_in_module(
             'goal setting block', 2,
             lambda (b): b.block().goal_type == 'services')
 

--- a/worth2/selftalk/models.py
+++ b/worth2/selftalk/models.py
@@ -5,6 +5,8 @@ from django.db import models
 from ordered_model.models import OrderedModel
 from pagetree.generic.models import BasePageBlock
 
+from worth2.main.utils import get_module_number
+
 
 class Statement(OrderedModel):
     """A negative statement.
@@ -115,10 +117,7 @@ class StatementBlock(BasePageBlock):
         ).delete()
 
     def __unicode__(self):
-        try:
-            slug = self.pageblock().section.get_parent().slug
-        except AttributeError:
-            slug = 'no section'
+        session_num = get_module_number(self.pageblock())
 
         if self.is_internal:
             block_subtype = 'Internal'
@@ -126,8 +125,8 @@ class StatementBlock(BasePageBlock):
             block_subtype = 'External'
             if self.subject_name:
                 block_subtype = self.subject_name + '\'s'
-        return '%s Statement Block [%s] id: %s' % (
-            block_subtype, slug, unicode(self.pk))
+        return '%s Statement Block [Session %d] id: %d' % (
+            block_subtype, session_num, self.pk)
 
     @staticmethod
     def add_form():
@@ -233,13 +232,9 @@ class RefutationBlock(BasePageBlock):
         ).delete()
 
     def __unicode__(self):
-        try:
-            slug = self.pageblock().section.get_parent().slug
-        except AttributeError:
-            slug = 'no section'
+        session_num = get_module_number(self.pageblock())
 
-        return '%s [%s] id: %s' % (
-            self.display_name, slug, unicode(self.pk))
+        return '%s [%d] id: %d' % (self.display_name, session_num, self.pk)
 
     @staticmethod
     def add_form():


### PR DESCRIPTION
I'm now referring to these as "modules" internally, while still
displaying this as "Session" in the UI.

This should fix the session display problem on the participant sign-in
page.