### PR TITLE
SSNM changes - PMT #100721, #100722

### DIFF
--- a/media/js/src/ssnm/controllers/supporters.js
+++ b/media/js/src/ssnm/controllers/supporters.js
@@ -29,13 +29,18 @@
         actions: {
             addSupporter: function() {
                 Em.debug('controller:supporters addSupporter');
-                var editSupporterController = this.get(
-                    'controllers.edit-supporter');
-                editSupporterController.setProperties({
-                    'isEditing': false,
-                    'model': this.store.createRecord('supporter')
-                });
-                this.send('openModal', 'edit-supporter-modal-1');
+                if (this.get('savedSupporters.length') < 5) {
+                    var editSupporterController = this.get(
+                        'controllers.edit-supporter');
+                    editSupporterController.setProperties({
+                        'isEditing': false,
+                        'model': this.store.createRecord('supporter')
+                    });
+                    this.send('openModal', 'edit-supporter-modal-1');
+                } else {
+                    Em.debug('Max supporters!');
+                    this.send('openModal', 'max-supporters-modal');
+                }
             },
 
             /**

--- a/media/js/src/ssnm/views/modal.js
+++ b/media/js/src/ssnm/views/modal.js
@@ -10,6 +10,18 @@
                 Em.debug('view:modal sending closeModal');
                 this.get('controller').send('closeModal');
             }
+        },
+        keyDown: function(e) {
+            Em.debug('view:modal keyDown');
+            if (e.keyCode === 13) {
+                // The user pressed Enter.
+                return false;
+            } else if (e.keyCode === 27) {
+                // The user pressed Escape.
+                Em.debug('view:keyDown sending closeModal');
+                this.get('controller').send('closeModal');
+                return false;
+            }
         }
     });
 })();

--- a/worth2/templates/ssnm/ssnm_js.html
+++ b/worth2/templates/ssnm/ssnm_js.html
@@ -1,6 +1,13 @@
 <script src="{{STATIC_URL}}js/lib/jquery.js"></script>
 <script src="{{STATIC_URL}}js/lib/ember-template-compiler.min.js"></script>
 
+<!-- When debugging / developing, inlude ember.debug.js here instead
+     of ember.min.js:
+       http://emberjs.com/builds/#/release
+
+     cd media/js/lib
+     wget http://builds.emberjs.com/release/ember.debug.js
+  -->
 <script src="{{STATIC_URL}}js/lib/ember.min.js"></script>
 <script src="{{STATIC_URL}}js/lib/ember-data.min.js"></script>
 

--- a/worth2/templates/ssnm/ssnm_page_block.html
+++ b/worth2/templates/ssnm/ssnm_page_block.html
@@ -127,6 +127,26 @@ HTML template - there's probably a way of avoiding that step.
     {{/if}}
 </script>
 
+<script type="text/x-handlebars" data-template-name="max-supporters-modal">
+    {{#modal-dialog action='closeModal'}}
+    <div class="ssnm-modal-header">
+        <h4>Too many people</h4>
+    </div>
+    <div class="ssnm-modal-body">
+        <p class="ssnm-modal-desc">
+            Sorry, this activity only works with at most <strong>5</strong>
+            people in your network. You can delete someone if you'd like
+            to add a new person.
+        </p>
+    </div>
+    <div class="ssnm-modal-footer">
+        <button {{action 'closeModal'}} class="btn btn-default">
+            Close
+        </button>
+    </div>
+    {{/modal-dialog}}
+</script>
+
 <script type="text/x-handlebars" data-template-name="edit-supporter-modal-1">
     {{#modal-dialog action='closeModal'}}
     <div class="ssnm-modal-header">


### PR DESCRIPTION
This adds a new "Too many people" dialog when you try to
add more than 5 supporters to your network map.

Also, I've added some key event behavior in the add/edit supporter
modals:
- When 'Escape' is pressed, the window closes.
- When 'Enter' is pressed, nothing happens.