### PR TITLE
Fix bug with Participant.highest_module_accessed

### DIFF
--- a/worth2/main/models.py
+++ b/worth2/main/models.py
@@ -233,7 +233,7 @@ class Participant(InactiveUserProfile):
         :rtype: int
         """
         module_sections = UserPageVisit.objects.filter(
-            user=self.user, section__depth=2
+            user=self.user, section__depth__gte=2
         ).distinct('section__slug')
 
         module_numbers = map(

--- a/worth2/main/tests/test_models.py
+++ b/worth2/main/tests/test_models.py
@@ -110,6 +110,25 @@ class ParticipantTest(TestCase):
         self.assertEqual(
             self.participant.highest_module_accessed(), 2)
 
+    @unittest.skipUnless(
+        settings.DATABASES['default']['ENGINE'] ==
+        'django.db.backends.postgresql_psycopg2',
+        "This test requires PostgreSQL")
+    def test_highest_module_accessed2(self):
+        section1 = Section.objects.get(slug='session-1')
+        upv1 = UserPageVisitFactory(
+            user=self.participant.user, section=section1)
+        Section.objects.get(slug='session-2')
+        goalsection = Section.objects.get(slug='goal-setting')
+        UserPageVisitFactory(user=self.participant.user, section=goalsection)
+        self.assertEqual(
+            self.participant.highest_module_accessed(), 2)
+
+        upv1.last_visit = datetime.now()
+        upv1.save()
+        self.assertEqual(
+            self.participant.highest_module_accessed(), 2)
+
     def test_last_module_accessed(self):
         self.assertEqual(
             self.participant.last_module_accessed(), -1)


### PR DESCRIPTION
This function wasn't looking at all the children of modules, only the
modules themselves.