### PR TITLE
Add Participant.next_module() - PMT #100689

### DIFF
--- a/worth2/templates/main/facilitator_sign_in_participant.html
+++ b/worth2/templates/main/facilitator_sign_in_participant.html
@@ -39,7 +39,7 @@
                     <option value="{{p.pk}}"
                             data-cohort-id="{{p.cohort_id|default:''}}"
                             data-last-location="{{p.last_location_verbose}}"
-                            data-next-location="{{p.next_location_verbose}}"
+                            data-next-location="{{p.next_module_verbose}}"
                             data-highest-accessed="{{p.highest_module_accessed}}">
                         {{p.study_id}}</option>
                     {% endfor %}


### PR DESCRIPTION
This fixes the bug where the module displayed in "The next, new session"
on the sign-in page is inaccurate.

This also fixes a bug with Participant.highest_module_accessed(),
which wasn't looking at all the children of modules, only the modules
themselves.