### PR TITLE
Fix Avatar Block form submit

### DIFF
--- a/worth2/templates/main/avatar_selector_block.html
+++ b/worth2/templates/main/avatar_selector_block.html
@@ -10,14 +10,16 @@
         <img class="thumbnail" src="{% avatar_url user %}">
     </div>
     {% else %}
-    {% for avatar in block.avatars %}
-    <span class="worth-avatar">
-        <img class="media" src="{{ avatar.image.url }}">
-    </span>
-    <button class="btn btn-default" type="submit"
-            name="pageblock-{{block.pageblock.pk}}-avatar-id"
-            value="{{ avatar.pk }}"
-            >This is me!</button>
-    {% endfor %}
+        <form action="." method="post">{% csrf_token %}
+        {% for avatar in block.avatars %}
+        <span class="worth-avatar">
+            <img class="media" src="{{ avatar.image.url }}">
+        </span>
+        <button class="btn btn-default" type="submit"
+                name="pageblock-{{block.pageblock.pk}}-avatar-id"
+                value="{{ avatar.pk }}"
+                >This is me!</button>
+        {% endfor %}
+        </form>
     {% endif %}
 </div>


### PR DESCRIPTION
At issue: The avatar block page was painting without a form, rendering the submit buttons useless.  

Explanation: By default, pagetree renders a form only if "needs_submit" is True and "is_submitted (pageblock.unlocked)" is False. (https://github.com/ccnmtl/worth2/blob/master/worth2/templates/pagetree/page.html#L52) The Avatar block wants to make submit optional, so returns True for needs_submit and is_unlocked. (https://github.com/ccnmtl/worth2/blob/master/worth2/main/models.py#L93)

Short-term resolution: Render the form inside the Avatar block template. This is fine as long as the Avatar Block is the only block on the page.

Longer-term: Ideally, the user would be forced to submit something, e.g. "No Thanks!", allowing a more consistent "unlocked" flow. Let's review the requirements for this.

