### PR TITLE
Javascript Debug Mode

### DIFF
--- a/worth2/templates/base.html
+++ b/worth2/templates/base.html
@@ -154,8 +154,14 @@
  {% endif %}
 </script>
 
+
+{% if debug %}
+<script data-main="{{STATIC_URL}}js/src/main.js"
+        src="{{STATIC_URL}}js/lib/require.js"></script>
+{% else %}
 <script data-main="{{STATIC_URL}}main-built.js"
         src="{{STATIC_URL}}js/lib/require.js"></script>
+{% endif %}
 
 {% block js %}
 {% endblock %}


### PR DESCRIPTION
When the application is in debug mode, Include all javascript source rather than the prebuilt require.js file.

Uses the django.core.context_processors.debug context processor:
https://docs.djangoproject.com/en/1.7/ref/templates/api/#django-core-context-processors-debug