### PR TITLE
Participant sign-in fixes, preliminary work for PMT #100768, #100773

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ cache: pip
 install:
   - ./bootstrap.py
 script:
-  - make
+  - make travis

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@ MANAGE=./manage.py
 APP=worth2
 FLAKE8=./ve/bin/flake8
 
-jenkins: ./ve/bin/python validate jshint jscs test flake8
+jenkins: ./ve/bin/python check jshint jscs test flake8
+
+travis: ./ve/bin/python check jshint jscs flake8
+	$(MANAGE) test
 
 ./ve/bin/python: requirements.txt bootstrap.py virtualenv.py
 	chmod +x manage.py bootstrap.py
@@ -33,14 +36,14 @@ test: ./ve/bin/python
 flake8: ./ve/bin/python
 	$(FLAKE8) $(APP) --max-complexity=10 --exclude=migrations
 
-runserver: ./ve/bin/python validate
+runserver: ./ve/bin/python check
 	$(MANAGE) runserver
 
-migrate: ./ve/bin/python validate jenkins
+migrate: ./ve/bin/python check jenkins
 	$(MANAGE) migrate
 
-validate: ./ve/bin/python
-	$(MANAGE) validate
+check: ./ve/bin/python
+	$(MANAGE) check
 
 shell: ./ve/bin/python
 	$(MANAGE) shell_plus
@@ -54,14 +57,14 @@ clean:
 
 pull:
 	git pull
-	make validate
+	make check
 	make test
 	make migrate
 	make flake8
 
 rebase:
 	git pull --rebase
-	make validate
+	make check
 	make test
 	make migrate
 	make flake8
@@ -69,14 +72,14 @@ rebase:
 syncdb: ./ve/bin/python
 	$(MANAGE) syncdb
 
-collectstatic: ./ve/bin/python validate
+collectstatic: ./ve/bin/python check
 	$(MANAGE) collectstatic --noinput --settings=$(APP).settings_production
 
 # run this one the very first time you check
 # this out on a new machine to set up dev
 # database, etc. You probably *DON'T* want
 # to run it after that, though.
-install: ./ve/bin/python validate jenkins
+install: ./ve/bin/python check jenkins
 	createdb $(APP)
 	$(MANAGE) syncdb --noinput
 	make migrate

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django==1.7.7
 Markdown==2.6.1
 smartypants==1.8.6
 uuid==1.30
-psycopg2==2.5.4
+psycopg2==2.6
 Pillow==2.8.1
 versiontools==1.9.1
 statsd==3.0.1
@@ -23,7 +23,7 @@ logilab-common==0.63.2
 logilab-astng==0.24.3
 pylint==1.4.1
 six==1.9.0
-factory_boy==2.4.1
+factory_boy==2.5.2
 sqlparse==0.1.14
 python-dateutil==2.4.0
 

--- a/worth2/goals/tests/test_models.py
+++ b/worth2/goals/tests/test_models.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from pagetree.helpers import get_hierarchy
 from worth2.goals.models import GoalSettingColumn, GoalCheckInColumn
 from worth2.goals.tests.factories import (
@@ -162,7 +162,9 @@ class GoalSettingColumnTest(TestCase):
         self.assertEquals(text.user_value(self.participant), "sample response")
 
 
-class GoalCheckInColumnTest(TestCase):
+class GoalCheckInColumnTest(TransactionTestCase):
+    reset_sequences = True
+
     def setUp(self):
         self.participant = ParticipantFactory().user
 
@@ -195,15 +197,19 @@ class GoalCheckInColumnTest(TestCase):
 
     def test_metadata(self):
         column = GoalCheckInColumn(self.block, 0, 'progress', 'yes', 'Yes')
-        self.assertEquals(column.metadata(),
-                          [u'main', u'1_services_0_progress',
-                           'Goal Check In Block', 'single choice',
-                           'Services 0 Checkin Progress', 'yes', 'Yes'])
+        self.assertEquals(
+            column.metadata(), [
+                u'main',
+                u'%d_services_0_progress' % self.block.goal_setting_block.id,
+                'Goal Check In Block', 'single choice',
+                u'Services 0 Checkin Progress', 'yes', 'Yes'
+            ])
         column = GoalCheckInColumn(self.block, 0, 'other')
-        self.assertEquals(column.metadata(),
-                          [u'main', u'1_services_0_other',
-                           'Goal Check In Block', 'string',
-                           'Services 0 Checkin Other'])
+        self.assertEquals(column.metadata(), [
+            u'main', u'%d_services_0_other' % self.block.goal_setting_block.id,
+            'Goal Check In Block', 'string',
+            u'Services 0 Checkin Other'
+        ])
 
     def test_user_values_no_responses(self):
         GoalCheckInColumn(self.block, 0, 'progress')

--- a/worth2/main/forms.py
+++ b/worth2/main/forms.py
@@ -29,7 +29,7 @@ class SignInParticipantForm(forms.Form):
         empty_label=None,
         queryset=Participant.objects.filter(
             is_archived=False).order_by('study_id'),
-        initial='Choose Participant',
+        initial='Choose a Participant',
     )
 
     participant_location = forms.ModelChoiceField(

--- a/worth2/main/tests/factories.py
+++ b/worth2/main/tests/factories.py
@@ -1,6 +1,6 @@
+import factory
 from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
-import factory
 from factory.fuzzy import FuzzyText
 from pagetree.tests.factories import RootSectionFactory
 from pagetree.models import UserPageVisit

--- a/worth2/main/tests/test_reports.py
+++ b/worth2/main/tests/test_reports.py
@@ -2,17 +2,19 @@ import datetime
 
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
-from django.test.testcases import TestCase
+from django.test.testcases import TransactionTestCase
 from pagetree.helpers import get_hierarchy
 from pagetree.models import Hierarchy, Section, UserPageVisit
 from pagetree.tests.factories import ModuleFactory
 
 from worth2.main.reports import ParticipantReport
-from worth2.main.tests.factories import (EncounterFactory, ParticipantFactory,
-                                         UserFactory, LocationFactory)
+from worth2.main.tests.factories import (
+    EncounterFactory, ParticipantFactory, UserFactory, LocationFactory
+)
 
 
-class ParticipantReportTest(TestCase):
+class ParticipantReportTest(TransactionTestCase):
+    reset_sequences = True
 
     def setUp(self):
         super(ParticipantReportTest, self).setUp()

--- a/worth2/main/views.py
+++ b/worth2/main/views.py
@@ -151,13 +151,6 @@ class SignInParticipant(FormView):
         facilitator = self.request.user
         password = generate_password(participant.user.username)
 
-        # I'm explicitly setting the participant's password each time
-        # they log in. In reality, this shouldn't have any effect. I'm
-        # doing this because when I don't, the authenticate() call
-        # below returns False during the tests.
-        participant.user.set_password(password)
-        participant.user.save()
-
         user = authenticate(
             username=participant.user.username, password=password)
 

--- a/worth2/templates/main/facilitator_sign_in_participant.html
+++ b/worth2/templates/main/facilitator_sign_in_participant.html
@@ -29,12 +29,12 @@
         <div class="form-group {% if form.participant_id.errors %}has-error{% endif %}">
             <label class="control-label col-sm-3"
                    for="{{form.participant_id.id_for_label}}">
-                Participant ID #</label>
+                {{ form.participant_id.field.label }}</label>
             <div class="col-sm-9">
                 <select class=" form-control" id="id_participant_id"
                         name="participant_id">
 
-                    <option>Choose a Participant</option>
+                    <option>{{ form.participant_id.field.initial }}</option>
                     {% for p in form.participant_id.field.choices %}
                     <option value="{{p.pk}}"
                             data-cohort-id="{{p.cohort_id|default:''}}"


### PR DESCRIPTION
I've fixed tests when using postgresql as test db, also, I'm now using
postgresql on travis, just like we're doing in PMT. This is because
there is some code that uses a postgresql-specific .distinct() method
that we need to be testing.

This commit also removes an unnecessary set_password() call in the
participant sign-in process.

Resolves PMT #100773