### PR TITLE
Fix validation on prot. behaviors quizzes - PMT #100763

### DIFF
--- a/worth2/protectivebehaviors/utils.py
+++ b/worth2/protectivebehaviors/utils.py
@@ -21,7 +21,7 @@ def remove_empty_submission(user, section):
         Q(css_extra__icontains='rate-my-risk')
     )
     quiztypes = ContentType.objects.filter(
-        Q(model='quiz') | Q(model='ratemyriskquiz'))
+        Q(app_label='quizblock'), Q(model='quiz'))
     quizblocks_on_this_page = [
         page.block() for page in
         pageblocks.filter(content_type__in=quiztypes)]

--- a/worth2/templates/pagetree/page.html
+++ b/worth2/templates/pagetree/page.html
@@ -48,9 +48,13 @@
 </script>
 
 <div id="content">
-{% if needs_submit and not is_submitted %}
-<form action="." method="post">{% csrf_token %}
-{% endif %}
+    {% if needs_submit and not is_submitted %}
+    <form action="." method="post">{% csrf_token %}
+    {% else %}
+        {% if is_submission_empty %}
+        <form action="." method="post">{% csrf_token %}
+        {% endif %}
+    {% endif %}
 
     {% for block in section.pageblock_set.all %}
 
@@ -73,6 +77,10 @@
 </div>
 
 {% if is_submitted %}
+{% if is_submission_empty %}
+{% include 'pagetree/pagetree_submit_button.html' %}
+{% else %}
+
 {% if allow_redo or user.is_superuser %}
 <div class="clearfix"></div>
 <form class="pagetree-form-submit-area"
@@ -80,7 +88,8 @@
     <input type="hidden" name="action" value="reset" />
     <input type="submit" value="I want to change my answers." class="btn" />
 </form>
-{% endif %}
+{% endif %}{# End allow_redo or user.is_superuser #}
+{% endif %}{# End is_submission_empty #}
 {% else %}
 
 <div class="clearfix"></div>
@@ -90,13 +99,15 @@ The avatar selector block needs to hide the submit button, since
 each avatar has its own submit button.
 {% endcomment %}
 {% if not avatarselectorblock %}
-<div class="pagetree-form-submit-area">
-    <input type="submit" value="Submit" class="btn btn-primary" />
-</div>
+{% include 'pagetree/pagetree_submit_button.html' %}
 {% endif %}
 
 </form>
 {% endif %}
+{% endif %}
+
+{% if is_submission_empty %}
+</form>
 {% endif %}
 
 {% include "pagetree/toc.html" %}

--- a/worth2/templates/pagetree/pagetree_submit_button.html
+++ b/worth2/templates/pagetree/pagetree_submit_button.html
@@ -1,0 +1,3 @@
+<div class="pagetree-form-submit-area">
+    <input type="submit" value="Submit" class="btn btn-primary" />
+</div>


### PR DESCRIPTION
I fixed this by messing with some of the if statements in the templates. The logic is very fragile here -- if it was any more complicated than this, I think each `pagetree.Section` should handle its own template.

![2015-04-23-131327_483x358_scrot](https://cloud.githubusercontent.com/assets/59292/7302926/df069220-e9ba-11e4-9357-aa5d5a994fa0.png)

![2015-04-23-131538_651x420_scrot](https://cloud.githubusercontent.com/assets/59292/7302928/e1614290-e9ba-11e4-9747-f0eb1d1a6f95.png)
