### PR TITLE
Put form feedback closer to selftalk form - PMT #100726

### DIFF
--- a/worth2/templates/selftalk/statement_block.html
+++ b/worth2/templates/selftalk/statement_block.html
@@ -11,22 +11,21 @@
         {% endif %}
     </p>
 
-    {% if messages %}
-    {% for message in messages %}
-    <div
-         {% if message.tags %}
-         class="alert alert-{{message.tags}}"
-         {% else %}
-         class="alert alert-info"
-         {% endif %}
-         >{{ message }}</div>
-    {% endfor %}
-    {% endif %}
-
-    {% bootstrap_form_errors statement_form %}
-
     <div class="worth-selftalk-flex-container">
         <div class="statement-form">
+            {% bootstrap_form_errors statement_form %}
+            {% if messages %}
+            {% for message in messages %}
+            <div
+                 {% if message.tags %}
+                 class="alert alert-{{message.tags}}"
+                 {% else %}
+                 class="alert alert-info"
+                 {% endif %}
+                 >{{ message }}</div>
+            {% endfor %}
+            {% endif %}
+
             {% bootstrap_form statement_form %}
         </div>
 


### PR DESCRIPTION
Marc may want to style this more, but this fixes the issue where
the feedback was bumping down the visual on the right.

![2015-04-23-135920_957x483_scrot](https://cloud.githubusercontent.com/assets/59292/7303827/2b1bed58-e9c1-11e4-82a2-c8fd9429c047.png)
