### PR TITLE
Add caching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -71,3 +71,4 @@ django-cacheds3storage==0.1.1
 inflection==0.2.1
 rest_framework_ember==1.2.0
 unicodecsv==0.11.2
+python-memcached==1.54

--- a/worth2/settings_production.py
+++ b/worth2/settings_production.py
@@ -18,6 +18,13 @@ DATABASES = {
     }
 }
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': '127.0.0.1:11211',
+    }
+}
+
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 AWS_S3_CUSTOM_DOMAIN = 'd1tpq2w6jljbie.cloudfront.net'

--- a/worth2/settings_shared.py
+++ b/worth2/settings_shared.py
@@ -21,6 +21,13 @@ DATABASES = {
     }
 }
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'worth2',
+    }
+}
+
 # Media settings
 MEDIA_URL = '/uploads/'
 MEDIA_ROOT = 'uploads'
@@ -89,6 +96,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 )
 
 MIDDLEWARE_CLASSES = (
+    'django.middleware.cache.UpdateCacheMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -100,6 +108,7 @@ MIDDLEWARE_CLASSES = (
     'impersonate.middleware.ImpersonateMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware',
     'waffle.middleware.WaffleMiddleware',
+    'django.middleware.cache.FetchFromCacheMiddleware',
 )
 
 ROOT_URLCONF = 'worth2.urls'

--- a/worth2/settings_staging.py
+++ b/worth2/settings_staging.py
@@ -18,6 +18,13 @@ DATABASES = {
     }
 }
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': '127.0.0.1:11211',
+    }
+}
+
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 STAGING_ENV = True


### PR DESCRIPTION
This adds caching to worth as described here:
https://docs.djangoproject.com/en/1.8/topics/cache/

For local development, this will use the LocMemCache backend, which requires no
setup for developers:
https://docs.djangoproject.com/en/1.8/topics/cache/#local-memory-caching

Optionally, you can still override this in local_settings.py to use a local
memcached instance.

On staging and production, worth will connect to memcached. I've added
memcached to scuba and django in salt.