### PR TITLE
Remove site-caching middleware

### DIFF
--- a/worth2/settings_shared.py
+++ b/worth2/settings_shared.py
@@ -96,7 +96,6 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 )
 
 MIDDLEWARE_CLASSES = (
-    'django.middleware.cache.UpdateCacheMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -108,7 +107,6 @@ MIDDLEWARE_CLASSES = (
     'impersonate.middleware.ImpersonateMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware',
     'waffle.middleware.WaffleMiddleware',
-    'django.middleware.cache.FetchFromCacheMiddleware',
 )
 
 ROOT_URLCONF = 'worth2.urls'


### PR DESCRIPTION
This middleware causes problems with the site.

For example, if I add a pageblock to a section, the edit
page will reload with a cached version of the section edit
page that doesn't contain the pageblock.