### PR TITLE
Add default empty view for goal checkin activity - PMT #100798

### DIFF
--- a/worth2/templates/goals/goal_check_in_block.html
+++ b/worth2/templates/goals/goal_check_in_block.html
@@ -3,7 +3,9 @@
 
 <div class="goal-check-in" id="goal-checkin-block">
 
+    {% if goal_checkin_context %}
     <p>Here's what you committed to do during the last session.</p>
+    {% endif %}
 
     <div class="container">
         <div class="row">
@@ -72,29 +74,36 @@
                         <div class="clearfix"></div>
                     </div><!-- end .checkin-group -->
                     <div class="clearfix"></div>
+                    {% empty %}
+                    <p>
+                        You haven't completed the goal setting activity for this check-in activity, so
+                        just continue to the next page.
+                    </p>
                     {% endfor %}
 
+                    {% if goal_checkin_context %}
                     <div class="form-group">
                         <button type="submit"
                                 class="btn btn-primary">Submit</button>
                     </div>
+                    {% endif %}
 
                 </form><!-- end .form-horizontal -->
             </div>
 
             <div class="col-sm-4 avatar-block text-center">
                 <img src="{% avatar_url user %}">
-                
-               
-<div class="panel panel-default text-left">
-  <div class="panel-heading">
-    <h3 class="panel-title">Tip</h3>
-  </div>
-  <div class="panel-body">
-    Panel content
-  </div>
-</div>               
-                
+
+
+                <div class="panel panel-default text-left">
+                    <div class="panel-heading">
+                        <h3 class="panel-title">Tip</h3>
+                    </div>
+                    <div class="panel-body">
+                        Panel content
+                    </div>
+                </div>
+
             </div>
 
         </div>


### PR DESCRIPTION
This adds some text to the goal checkin activity if the participant hasn't completed the associated setting activity.

![2015-04-27-101750_673x177_scrot](https://cloud.githubusercontent.com/assets/59292/7349434/f861d9c8-ecc6-11e4-9f85-3364a1134e3d.png)
