### PR TITLE
Quizblock Required Answer Enhancement

### DIFF
--- a/media/js/src/views/quiz-validator.js
+++ b/media/js/src/views/quiz-validator.js
@@ -25,9 +25,11 @@ define([
                 var hasAnyCheckedCheckboxes = _.reduce(
                     $requiredCheckboxes,
                     function(memo, $el) {
-                        return memo || $($el).is(':checked');
+                        var grpName = $($el).attr('name');
+                        var grp = $('input:checkbox[name="' + grpName + '"]');
+                        return memo && $(grp).is(':checked');
                     },
-                    false);
+                    true);
 
                 if ($requiredCheckboxes.length > 0 &&
                     !hasAnyCheckedCheckboxes
@@ -48,9 +50,11 @@ define([
             var hasAnyCheckedRadioButtons = _.reduce(
                 $radioButtons,
                 function(memo, $el) {
-                    return memo || $($el).is(':checked');
+                    var grpName = $($el).attr('name');
+                    var grp = $('input:radio[name="' + grpName + '"]');
+                    return memo && $(grp).is(':checked');
                 },
-                false);
+                true);
 
             if ($radioButtons.length > 0 && !hasAnyCheckedRadioButtons) {
                 return false;


### PR DESCRIPTION
The quizblock-validator previously mandated at least one answer was selected across a question type (single answer, multiple answer). As Worth quizzes generally are a single question, this approach worked fine.

The (new) Evaluation Quiz adds the complexity of a quiz with multiple questions of mixed type (single answer, multiple answer, short text, long text). In this case, the validator failed to correctly validate single answer & multiple answer questions.

For example, given 3 single answer questions, true was returned if just one question was answered.

This patch updates the quiz-validator to ensure at least one answer is checked for each question.