### PR TITLE
Remove uuid dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 Django==1.8.1
 Markdown==2.6.1
 smartypants==1.8.6
-uuid==1.30
 psycopg2==2.6
 Pillow==2.8.1
 versiontools==1.9.1


### PR DESCRIPTION
I don't think any dependencies are using this package -- if they were then pip
would complain because we're using `--no-deps`