### PR TITLE
Remove django-ga-context

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,6 @@ django-jenkins==0.17.0
 django-smoketest==0.3.0
 django-extensions==1.4.9
 django-stagingcontext==0.1.0
-django-ga-context==0.1.0
 django-impersonate==0.9
 django-registration-redux==1.1
 django-treebeard==3.0


### PR DESCRIPTION
Worth doesn't use google analytics, so we don't need this package.