### PR TITLE
Remove last_module_accessed method - PMT #100973

### DIFF
--- a/worth2/main/models.py
+++ b/worth2/main/models.py
@@ -247,17 +247,6 @@ class Participant(InactiveUserProfile):
         else:
             return -1
 
-    def last_module_accessed(self):
-        """Get which module this participant is in.
-
-        :rtype: int
-        """
-        last_section = self.last_location()
-        if last_section:
-            return get_module_number_from_section(last_section.get_module())
-        else:
-            return -1
-
     def next_module(self):
         """Get the next module that the participant needs to complete.
 

--- a/worth2/main/tests/test_models.py
+++ b/worth2/main/tests/test_models.py
@@ -119,28 +119,6 @@ class ParticipantTest(TestCase):
         self.assertEqual(
             self.participant.highest_module_accessed(), 2)
 
-    def test_last_module_accessed(self):
-        self.assertEqual(
-            self.participant.last_module_accessed(), -1)
-
-        section1 = Section.objects.get(slug='session-1')
-        upv1 = UserPageVisitFactory(
-            user=self.participant.user, section=section1)
-        self.assertEqual(
-            self.participant.last_module_accessed(), 1)
-
-        section2 = Section.objects.get(slug='session-2')
-        goalsection = Section.objects.get(slug='goal-setting')
-        UserPageVisitFactory(user=self.participant.user, section=section2)
-        UserPageVisitFactory(user=self.participant.user, section=goalsection)
-        self.assertEqual(
-            self.participant.last_module_accessed(), 2)
-
-        upv1.last_visit = datetime.now()
-        upv1.save()
-        self.assertEqual(
-            self.participant.last_module_accessed(), 1)
-
     def test_next_module(self):
         self.assertEqual(
             self.participant.next_module(), 1,

--- a/worth2/templates/main/participant_edit_row.html
+++ b/worth2/templates/main/participant_edit_row.html
@@ -114,7 +114,7 @@
                     >Participant {{participant.study_id}}'s progress</h4>
             </div>
             <div class="modal-body" style="text-align: center;">
-                {% with last_module=participant.last_module_accessed %}
+                {% with last_module=participant.highest_module_accessed %}
                 <div class="table-container center-block">
                     <table class="table table-condensed col-sm-2">
                         <tbody>


### PR DESCRIPTION
Using instead the `Participant.highest_module_accessed` when
indicating participant progress.