### PR TITLE
remove run_pylint step

### DIFF
--- a/worth2/settings_shared.py
+++ b/worth2/settings_shared.py
@@ -61,7 +61,6 @@ if 'test' in sys.argv or 'jenkins' in sys.argv:
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
 JENKINS_TASKS = (
-    'django_jenkins.tasks.run_pylint',
     'django_jenkins.tasks.with_coverage',
     'django_jenkins.tasks.run_pep8',
     'django_jenkins.tasks.run_pyflakes',


### PR DESCRIPTION
Jenkins isn't looking at the output from it, and it's very slow.

On my system, removing it reduces the time to run 'make' by 70 seconds