### PR TITLE
Handle duplicate requests to /api/watched_videos/

### DIFF
--- a/worth2/main/apiviews.py
+++ b/worth2/main/apiviews.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import authenticate, login
 from django.contrib.auth.models import User
+from django.db import IntegrityError
 from rest_framework import viewsets, permissions
 from rest_framework.views import APIView
 from rest_framework.response import Response
@@ -61,4 +62,9 @@ class WatchedVideoViewSet(viewsets.ModelViewSet):
         return self.request.user.watched_videos.all()
 
     def perform_create(self, serializer):
-        serializer.save(user=self.request.user)
+        try:
+            serializer.save(user=self.request.user)
+        except IntegrityError:
+            # TODO: is there something we can raise here
+            # to get DRF to return a 304 in this case?
+            pass

--- a/worth2/main/tests/test_apiviews.py
+++ b/worth2/main/tests/test_apiviews.py
@@ -192,3 +192,18 @@ class WatchedVideoViewSetTest(
         r = self.client.get('/api/watched_videos/')
         self.assertEqual(r.status_code, 200)
         self.assertEqual(len(r.data), 3)
+
+    def test_create_duplicate(self):
+        video_id = 'test_video_id'
+        r = self.client.post('/api/watched_videos/', {'video_id': video_id})
+        self.assertEqual(r.status_code, status.HTTP_201_CREATED)
+
+        objs = WatchedVideo.objects.filter(user=self.u)
+        self.assertEqual(objs.count(), 1)
+        self.assertEqual(objs.first().video_id, video_id)
+
+        # re-run it
+        r = self.client.post('/api/watched_videos/', {'video_id': video_id})
+        # TODO: this ought to be a 304 Not Modified, not a 201
+        # but at the very least, it shouldn't be a 500
+        self.assertNotEqual(r.status_code, 500)


### PR DESCRIPTION
Seeing a lot of these: https://sentry.ccnmtl.columbia.edu/sentry-internal/worth2/group/659/

Probably from someone double-clicking submit or something.

At any rate, submitting multiple times ought to be harmless, rather than a 500 error.

Ideally, the response should be a 304 Not Modified, but I couldn't see
a straightforward way to get DRF to generate that.