### PR TITLE
Behave fixes

### DIFF
--- a/bdd_tests/features/intervention.feature
+++ b/bdd_tests/features/intervention.feature
@@ -49,7 +49,7 @@ Feature: Participant Intervention
     Then I am at the url "/pages/session-2/goal-setting-section/"
 
     When I click the goal submit button
-    Then I see the text "Oops!"
+    Then I don't see the text "1 goal saved"
 
     When I fill in a goal option
     When I click the goal submit button

--- a/bdd_tests/features/participant_signin.feature
+++ b/bdd_tests/features/participant_signin.feature
@@ -1,6 +1,7 @@
 Feature: Participant Sign In Page
   Scenario: Participant Sign In
-    Given I am signed in as a facilitator
+    Given I am not logged in
+    When I sign in as a facilitator
     When I access the url "/sign-in-participant/"
     Then I see the text "Sign In My Participant"
 

--- a/bdd_tests/steps/auth.py
+++ b/bdd_tests/steps/auth.py
@@ -42,3 +42,12 @@ def i_am_signed_in_as_a(context, user_type):
     user, s = create_pre_authenticated_session(user_type)
     b.cookies.add({'name': settings.SESSION_COOKIE_NAME, 'value': s})
     context.user = user
+
+
+@given(u'I am not logged in')
+def i_am_not_logged_in(context):
+    context.browser.cookies.delete()
+    try:
+        context.user = None
+    except:
+        pass

--- a/bdd_tests/steps/common.py
+++ b/bdd_tests/steps/common.py
@@ -1,7 +1,8 @@
 from behave import when, then
 
-from worth2.main.models import Location, Participant
-from worth2.main.tests.factories import UserFactory
+from worth2.main.auth import generate_password
+from worth2.main.models import Location
+from worth2.main.tests.factories import UserFactory, ParticipantFactory
 
 
 @when(u'I sign in as a facilitator')
@@ -21,7 +22,11 @@ def i_sign_in_as_a_facilitator(context):
 def i_sign_in_as_a_participant(context):
     i_sign_in_as_a_facilitator(context)
 
-    participant = Participant.objects.first()
+    participant = ParticipantFactory()
+    password = generate_password(participant.user.username)
+    participant.user.set_password(password)
+    participant.user.save()
+
     location = Location.objects.first()
 
     b = context.browser
@@ -53,7 +58,12 @@ def i_click_the_submit_button(context):
 
 @then(u'I see the text "{text}"')
 def i_see_the_text(context, text):
-    context.browser.is_text_present(text)
+    assert context.browser.is_text_present(text)
+
+
+@then(u'I don\'t see the text "{text}"')
+def i_dont_see_the_text(context, text):
+    assert context.browser.is_text_not_present(text)
 
 
 @then(u'I get a {status_code}')

--- a/worth2/main/tests/factories.py
+++ b/worth2/main/tests/factories.py
@@ -5,7 +5,9 @@ from factory.fuzzy import FuzzyText
 from pagetree.tests.factories import HierarchyFactory, RootSectionFactory
 from pagetree.models import UserPageVisit
 
-from worth2.goals.models import GoalOption, GoalSettingBlock
+from worth2.goals.models import (
+    GoalCheckInPageBlock, GoalOption, GoalSettingBlock
+)
 from worth2.main.auth import generate_password
 from worth2.main.models import (
     Avatar, Encounter, Location, Participant, VideoBlock, WatchedVideo
@@ -487,12 +489,14 @@ class WorthModuleFactory(object):
                     'slug': 'goal-check-in-section',
                     'pageblocks': [{
                         'block_type': 'Goal Check In Block',
-                        'goal_setting_block':
-                            GoalSettingBlock.objects.first()
                     }],
                 },
             ]
         })
+        b = GoalCheckInPageBlock.objects.first()
+        b.goal_setting_block = GoalSettingBlock.objects.first()
+        b.save()
+        assert(b.goal_setting_block is not None)
 
         root.add_child_section_from_dict({
             'label': 'Welcome to Session 3',
@@ -510,12 +514,14 @@ class WorthModuleFactory(object):
                     'slug': 'risk-goal-review',
                     'pageblocks': [{
                         'block_type': 'Goal Check In Block',
-                        'goal_setting_block':
-                            GoalSettingBlock.objects.first()
                     }],
                 },
             ],
         })
+        b = GoalCheckInPageBlock.objects.all()[1]
+        b.goal_setting_block = GoalSettingBlock.objects.first()
+        b.save()
+        assert(b.goal_setting_block is not None)
 
         root.add_child_section_from_dict({
             'label': 'Welcome to Session 4',

--- a/worth2/templates/pagetree/page.html
+++ b/worth2/templates/pagetree/page.html
@@ -77,6 +77,8 @@
       action="." method="post">{% csrf_token %}
     <input type="hidden" name="action" value="reset" />
     <input type="submit" value="I want to change my answers." class="btn btn-primary" />
+{% endif %}{# End allow_redo or user.is_superuser #}
+{% endif %}{# End is_submission_empty #}
     {% if messages %}
         {% for message in messages %}
             <div
@@ -88,6 +90,8 @@
                  >{{ message }}</div>
         {% endfor %}
     {% endif %}
+{% if allow_redo or user.is_superuser %}
+{% if is_submission_empty %}
 </form>
 {% endif %}{# End allow_redo or user.is_superuser #}
 {% endif %}{# End is_submission_empty #}


### PR DESCRIPTION
One of the "Then" functions in the bdd steps didn't have an `assert`
on it, so it wasn't doing anything. This uncovered a bug with the
success alert on the goal setting page, and some problems with the
behave tests, which I've fixed.

I haven't gotten the create_pre_authenticated_session stuff to work,
even for normal, non-participant users, but doing the manual
sign-in is working for now.