### PR TITLE
Make GoalCheckInResponse.goal_setting_response a OneToOneField

### DIFF
--- a/worth2/goals/migrations/0018_auto_20150702_1256.py
+++ b/worth2/goals/migrations/0018_auto_20150702_1256.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('goals', '0017_auto_20150312_0940'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='goalcheckinresponse',
+            name='goal_setting_response',
+            field=models.OneToOneField(related_name='goal_checkin_response', to='goals.GoalSettingResponse'),
+        ),
+    ]

--- a/worth2/goals/models.py
+++ b/worth2/goals/models.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib.auth.models import User
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.template.defaultfilters import slugify
 from django.utils.encoding import smart_str
@@ -255,9 +256,8 @@ class GoalCheckInResponse(models.Model):
     This is only used on sessions 2 through 5.
     """
 
-    goal_setting_response = models.ForeignKey(
+    goal_setting_response = models.OneToOneField(
         GoalSettingResponse,
-        unique=True,
         related_name='goal_checkin_response'
     )
 
@@ -309,7 +309,13 @@ class GoalCheckInPageBlock(BasePageBlock):
             return True
 
         for setting_response in setting_responses:
-            if setting_response.goal_checkin_response.count() > 0:
+            checkin_response = None
+            try:
+                checkin_response = setting_response.goal_checkin_response
+            except ObjectDoesNotExist:
+                continue
+
+            if checkin_response is not None:
                 return True
 
         return False


### PR DESCRIPTION
This fixes this warning that started appearing in Django 1.8:

    goals.GoalCheckInResponse.goal_setting_response: (fields.W342) Setting
    unique=True on a ForeignKey has the same effect as using a
    OneToOneField.

    HINT: ForeignKey(unique=True) is usually better served by a
    OneToOneField.