### PR TITLE
Play high-res video on retina display iPad

### DIFF
--- a/media/css/video.css
+++ b/media/css/video.css
@@ -10,3 +10,15 @@
 #worth-youtube-video-duration time {
     font-weight: bold;
 }
+
+@media
+(-webkit-min-device-pixel-ratio: 2),
+(min-resolution: 192dpi) {
+    /* Retina-specific stuff here */
+    iframe#youtube-player {
+        width: 200%;
+        height: 200%;
+        -webkit-transform-origin: left top;
+        -webkit-transform: scale(.5);
+    }
+}

--- a/media/css/video.css
+++ b/media/css/video.css
@@ -15,7 +15,7 @@
 (-webkit-min-device-pixel-ratio: 2),
 (min-resolution: 192dpi) {
     /* Retina-specific stuff here */
-    iframe#youtube-player {
+    #youtube-player {
         width: 200%;
         height: 200%;
         -webkit-transform-origin: left top;


### PR DESCRIPTION
This causes the youtube iframe api to play high-res
videos instead of the low-res ones it defaults to, because
of the low `<video>` dimensions caused by the retina display.

This is related to, but doesn't fix, the low-quality thumbnails
(PMT #102083).