### PR TITLE
Revert validation removal - PMT #103443

### DIFF
--- a/worth2/main/migrations/0021_auto_20151026_0929.py
+++ b/worth2/main/migrations/0021_auto_20151026_0929.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.core.validators
+import worth2.main.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0020_auto_20151016_0942'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='participant',
+            name='study_id',
+            field=models.CharField(db_index=True, unique=True, max_length=255, validators=[django.core.validators.RegexValidator(regex=b'^[1-2]\\d[0-1]\\d[0-3]\\d\\d\\d[0-2]\\d[0-5]\\d$', message=b"That study ID isn't valid. The format is: YYMMDDLLHHMM (where LL is the two-digit location code)."), worth2.main.models.study_id_validator]),
+        ),
+    ]

--- a/worth2/main/models.py
+++ b/worth2/main/models.py
@@ -230,7 +230,9 @@ class Participant(InactiveUserProfile):
     # into our system.
     study_id = models.CharField(max_length=255,
                                 unique=True,
-                                db_index=True)
+                                db_index=True,
+                                validators=[study_id_regex_validator,
+                                            study_id_validator])
 
     # The cohort ID is assigned when the participant begins the second
     # session. It represents the group of all the participants present

--- a/worth2/main/tests/test_apiviews.py
+++ b/worth2/main/tests/test_apiviews.py
@@ -70,16 +70,19 @@ class ParticipantViewSetTest(
         participant = Participant.objects.get(study_id=study_id)
         self.assertEqual(participant.study_id, study_id)
 
-    def test_update_study_id_accepts_invalid(self):
+    def test_update_study_id_invalid(self):
         study_id = '160022672101'
         p = ParticipantFactory(study_id=study_id)
         response = self.client.put(
             '/api/participants/' + unicode(p.pk) + '/',
             {'study_id': '15042672101'}
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('That study ID isn\'t valid.',
+                      response.data['study_id'][0])
 
-        Participant.objects.get(study_id='15042672101')
+        with self.assertRaises(Participant.DoesNotExist):
+            Participant.objects.get(study_id='15042672101')
 
     def test_update_cohort_id(self):
         study_id = '160022672101'

--- a/worth2/main/tests/test_models.py
+++ b/worth2/main/tests/test_models.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 from pagetree.models import Hierarchy, Section
 
@@ -66,9 +67,10 @@ class ParticipantTest(TestCase):
     def test_is_valid_from_factory(self):
         self.participant.full_clean()
 
-    def test_accepts_random_study_id(self):
+    def test_is_invalid_with_bad_study_id(self):
         p = ParticipantFactory(study_id='666')
-        p.full_clean()
+        with self.assertRaises(ValidationError):
+            p.full_clean()
 
     def test_that_participant_can_have_an_image(self):
         self.participant.avatar = AvatarFactory()


### PR DESCRIPTION
Turns out we do want validation.

This reverts commit 69fd071ca40dd895388af388259b72983053723c,
and adds a migration to re-add this validation.