### PR TITLE
Implement new study ID format - PMT #104086

### DIFF
--- a/worth2/main/migrations/0022_auto_20151204_0916.py
+++ b/worth2/main/migrations/0022_auto_20151204_0916.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0021_auto_20151026_0929'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='participant',
+            name='study_id',
+            field=models.CharField(db_index=True, unique=True, max_length=255, validators=[django.core.validators.RegexValidator(regex=b'^\\d\\d[0-2]\\d[0-5]\\d[0-3]\\d[0-1]\\d[5-7][1-5][1-2]$', message=b"That study ID isn't valid. The format is: RRHHMMDDMMYBS")]),
+        ),
+    ]

--- a/worth2/main/models.py
+++ b/worth2/main/models.py
@@ -1,4 +1,3 @@
-import re
 from django import forms
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -168,28 +167,25 @@ class Location(models.Model):
 #
 # Some of these types of users have special data associated with them.
 
-# ID spec is here:
-# http://wiki.ccnmtl.columbia.edu/index.php/WORTH_2_User_Stories#Participant_ID_number_scheme
+# ID spec is the 12-digit string: RRHHMMDDMMYBS
+# where the letters correspond to the following:
+# RR Research Assistant
+# HH hour (24-hour)
+# MM minute
+# DD day
+# MM month
+# Y last digit of year (5, 6 or 7)
+# B borough (Bronx=1, Brooklyn=2, Manhattan=3, Queens=4, Staten Island=5)
+# S (Fortune site: 1=LIC; 2=Harlem)
 study_id_regex_validator = RegexValidator(
-    regex=r'^[1-2]\d[0-1]\d[0-3]\d\d\d[0-2]\d[0-5]\d$',
+    regex=r'^\d\d[0-2]\d[0-5]\d[0-3]\d[0-1]\d[5-7][1-5][1-2]$',
     message='That study ID isn\'t valid. ' +
-    'The format is: YYMMDDLLHHMM (where LL is the two-digit location code).')
+    'The format is: RRHHMMDDMMYBS')
 
 
 def study_id_validator(value):
     """Validate study ID for anything the regex can't capture."""
-    year = None
-    try:
-        year = re.match(r'^(\d\d)\d+$', value).groups()[0]
-        year = int(year)
-    except:
-        raise ValidationError('Couldn\'t find year in study ID.')
-
-    if year < 15 or year > 25:
-        raise ValidationError(
-            'The first two digits of the study ID ' +
-            ('(%d), which represent the year, need ' % year) +
-            'to be between 15 and 25.')
+    pass
 
 
 # For now, accept any 3-digit number as the cohort ID.
@@ -231,8 +227,7 @@ class Participant(InactiveUserProfile):
     study_id = models.CharField(max_length=255,
                                 unique=True,
                                 db_index=True,
-                                validators=[study_id_regex_validator,
-                                            study_id_validator])
+                                validators=[study_id_regex_validator])
 
     # The cohort ID is assigned when the participant begins the second
     # session. It represents the group of all the participants present

--- a/worth2/main/tests/factories.py
+++ b/worth2/main/tests/factories.py
@@ -54,7 +54,7 @@ class ParticipantFactory(factory.django.DjangoModelFactory):
     user = factory.SubFactory(InactiveUserFactory)
     first_location = factory.SubFactory(LocationFactory)
     location = factory.SubFactory(LocationFactory)
-    study_id = factory.Sequence(lambda n: '15040%03d1245' % n)
+    study_id = factory.Sequence(lambda n: '%02d22591304632' % n)
 
 
 class EncounterFactory(factory.django.DjangoModelFactory):

--- a/worth2/main/tests/test_apiviews.py
+++ b/worth2/main/tests/test_apiviews.py
@@ -46,7 +46,7 @@ class LoginCheckTest(LoggedInParticipantTestMixin, APITestCase):
 class ParticipantViewSetTest(
         LoggedInFacilitatorTestMixin, APITestCase):
     def test_create(self):
-        study_id = '150426781012'
+        study_id = '0122371304632'
         response = self.client.post(
             '/api/participants/', {'study_id': study_id}
         )
@@ -58,8 +58,8 @@ class ParticipantViewSetTest(
         self.assertEqual(participant.created_by, self.u)
 
     def test_update_study_id(self):
-        p = ParticipantFactory(study_id='150426781012')
-        study_id = '160022672101'
+        p = ParticipantFactory(study_id='0122371304632')
+        study_id = '0122371304631'
         response = self.client.put(
             '/api/participants/' + unicode(p.pk) + '/',
             {'study_id': study_id}
@@ -71,21 +71,22 @@ class ParticipantViewSetTest(
         self.assertEqual(participant.study_id, study_id)
 
     def test_update_study_id_invalid(self):
-        study_id = '160022672101'
+        study_id = '0122251304634'
+        bad_study_id = '0122371304639'
         p = ParticipantFactory(study_id=study_id)
         response = self.client.put(
             '/api/participants/' + unicode(p.pk) + '/',
-            {'study_id': '15042672101'}
+            {'study_id': bad_study_id}
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn('That study ID isn\'t valid.',
                       response.data['study_id'][0])
 
         with self.assertRaises(Participant.DoesNotExist):
-            Participant.objects.get(study_id='15042672101')
+            Participant.objects.get(study_id=bad_study_id)
 
     def test_update_cohort_id(self):
-        study_id = '160022672101'
+        study_id = '0122251304631'
         p = ParticipantFactory(study_id=study_id, cohort_id='111')
         response = self.client.put(
             '/api/participants/' + unicode(p.pk) + '/', {
@@ -100,7 +101,7 @@ class ParticipantViewSetTest(
         self.assertEqual(participant.cohort_id, '787')
 
     def test_update_cohort_id_invalid(self):
-        study_id = '160022672101'
+        study_id = '0122251304634'
         p = ParticipantFactory(study_id=study_id, cohort_id='111')
         response = self.client.put(
             '/api/participants/' + unicode(p.pk) + '/', {
@@ -117,10 +118,11 @@ class ParticipantViewSetTest(
             Participant.objects.get(cohort_id='j87878')
 
     def test_update_archive(self):
-        p = ParticipantFactory(is_archived=False)
+        study_id = '0122371304632'
+        p = ParticipantFactory(study_id=study_id, is_archived=False)
         response = self.client.put(
             '/api/participants/' + unicode(p.pk) + '/',
-            {'study_id': p.study_id, 'is_archived': True}
+            {'study_id': study_id, 'is_archived': True}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -130,7 +132,7 @@ class ParticipantViewSetTest(
 
 class ParticipantViewSetUnAuthedTest(APITestCase):
     def test_create(self):
-        study_id = '160022672101'
+        study_id = '0122251304631'
         response = self.client.post(
             '/api/participants/', {'study_id': study_id}
         )
@@ -140,16 +142,17 @@ class ParticipantViewSetUnAuthedTest(APITestCase):
             Participant.objects.get(study_id=study_id)
 
     def test_update_study_id(self):
-        study_id = '160022672101'
+        study_id = '0122251304631'
+        good_study_id = '0122251304632'
         p = ParticipantFactory(study_id=study_id)
         response = self.client.put(
             '/api/participants/' + unicode(p.pk) + '/',
-            {'study_id': '150426781012'}
+            {'study_id': good_study_id}
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         with self.assertRaises(Participant.DoesNotExist):
-            Participant.objects.get(study_id='150426781012')
+            Participant.objects.get(study_id=good_study_id)
 
 
 class WatchedVideoViewSetUnAuthedTest(APITestCase):

--- a/worth2/main/tests/test_models.py
+++ b/worth2/main/tests/test_models.py
@@ -72,6 +72,10 @@ class ParticipantTest(TestCase):
         with self.assertRaises(ValidationError):
             p.full_clean()
 
+        p = ParticipantFactory(study_id='12345678901')
+        with self.assertRaises(ValidationError):
+            p.full_clean()
+
     def test_that_participant_can_have_an_image(self):
         self.participant.avatar = AvatarFactory()
 

--- a/worth2/templates/main/participant_edit_row.html
+++ b/worth2/templates/main/participant_edit_row.html
@@ -55,28 +55,33 @@
             </div>
             <form class="worth-edit-participant form-inline" role="form">
                 {% csrf_token %}
-                <div class="modal-body" style="text-align: center;">
-                    <div class="alert alert-danger worth-errors"
-                         style="display: none;"></div>
-                    <div class="alert alert-success worth-success"
-                         style="display: none;">Participant saved.</div>
+                <div class="modal-body">
 
-                    <div class="form-group">
-                        <label>
-                            Study ID #
-                            <input type="text" class="form-control"
-                                   name="study_id"
-                                   value="{{participant.study_id}}" />
-                        </label>
-                    </div>
+                    {% include 'main/participant_id_instructions.html' %}
 
-                    <div class="form-group">
-                        <label>
-                            Cohort ID #
-                            <input type="text" class="form-control"
-                                   name="cohort_id"
-                                   value="{{participant.cohort_id|default_if_none:''}}" />
-                        </label>
+                    <div style="text-align: center;">
+                        <div class="alert alert-danger worth-errors"
+                             style="display: none;"></div>
+                        <div class="alert alert-success worth-success"
+                             style="display: none;">Participant saved.</div>
+
+                        <div class="form-group">
+                            <label>
+                                Study ID #
+                                <input type="text" class="form-control"
+                                       name="study_id"
+                                       value="{{participant.study_id}}" />
+                            </label>
+                        </div>
+
+                        <div class="form-group">
+                            <label>
+                                Cohort ID #
+                                <input type="text" class="form-control"
+                                       name="cohort_id"
+                                       value="{{participant.cohort_id|default_if_none:''}}" />
+                            </label>
+                        </div>
                     </div>
 
                 </div>

--- a/worth2/templates/main/participant_id_instructions.html
+++ b/worth2/templates/main/participant_id_instructions.html
@@ -1,0 +1,40 @@
+<div class="worth-id-instructions">
+    <p>
+        The study ID format is the 12-digit string:
+        <strong>RRHHMMDDMMYBS</strong>
+        where the letters correspond to the following:
+    </p>
+    <ul>
+        <li>
+            <strong>RR</strong> - Research Assistant
+        </li>
+        <li>
+            <strong>HH</strong> - hour (24-hour clock)
+        </li>
+        <li>
+            <strong>MM</strong> - minute
+        </li>
+        <li>
+            <strong>DD</strong> - day
+        </li>
+        <li>
+            <strong>MM</strong> - month
+        </li>
+        <li>
+            <strong>Y</strong> - last digit of year
+            (<strong>5</strong>, <strong>6</strong>,
+            or <strong>7</strong>)
+        </li>
+        <li>
+            <strong>B</strong> - borough
+            (Bronx=<strong>1</strong>,
+            Brooklyn=<strong>2</strong>,
+            Manhattan=<strong>3</strong>,
+            Queens=<strong>4</strong>,
+            Staten Island=<strong>5</strong>)
+        </li>
+        <li>
+            <strong>S</strong> - Fortune site (LIC=<strong>1</strong>, Harlem=<strong>2</strong>)
+        </li>
+    </ul>
+</div>

--- a/worth2/templates/main/participant_list.html
+++ b/worth2/templates/main/participant_list.html
@@ -58,20 +58,24 @@
                     <span class="sr-only">Close</span>
                 </button>
                 <h4 class="modal-title">Add Participant ID</h4>
+
             </div>
             <form id="worth-create-participant"
                   class="form-inline" role="form">
-                <div class="modal-body"
-                     style="text-align: center;">
-                    <div class="alert alert-danger worth-errors"
-                         style="display: none;"></div>
-                    <div class="alert alert-success worth-success"
-                         style="display: none;">Participant created.</div>
-                    <div class="form-group">
-                        <label>
-                            Study ID # <input type="text" class="form-control"
-                                              name="study_id" />
-                        </label>
+                <div class="modal-body">
+                    {% include 'main/participant_id_instructions.html' %}
+
+                    <div style="text-align: center;">
+                        <div class="alert alert-danger worth-errors"
+                             style="display: none;"></div>
+                        <div class="alert alert-success worth-success"
+                             style="display: none;">Participant created.</div>
+                        <div class="form-group">
+                            <label>
+                                Study ID # <input type="text" class="form-control"
+                                                  name="study_id" />
+                            </label>
+                        </div>
                     </div>
                 </div>
                 <div class="modal-footer">


### PR DESCRIPTION
This change is fine to be pushed whenever: the old participants (there
are 3 on production) will stay on the system, and we can update their
replacement IDs when we have them. I had told Jess we would need to
manually make a migration to handle this, and that we need the
replacement IDs in order to make this change, but it turns out that's
not the case.