### PR TITLE
Fix study id description

### DIFF
--- a/worth2/main/models.py
+++ b/worth2/main/models.py
@@ -167,7 +167,7 @@ class Location(models.Model):
 #
 # Some of these types of users have special data associated with them.
 
-# ID spec is the 12-digit string: RRHHMMDDMMYBS
+# ID spec is the 13-digit string: RRHHMMDDMMYBS
 # where the letters correspond to the following:
 # RR Research Assistant
 # HH hour (24-hour)

--- a/worth2/templates/main/participant_id_instructions.html
+++ b/worth2/templates/main/participant_id_instructions.html
@@ -1,6 +1,6 @@
 <div class="worth-id-instructions">
     <p>
-        The study ID format is the 12-digit string:
+        The study ID consists of 13 digits:
         <strong>RRHHMMDDMMYBS</strong>
         where the letters correspond to the following:
     </p>


### PR DESCRIPTION
Woops... the format is 13 digits not 12. Also, I've changed the
wording because the term "string" could mean any number of things
outside the context of programming.