### PR TITLE
Behave/Selenium fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 sudo: false
 addons:
-  firefox: "41.0.1"
+  firefox: "43.0"
 python:
   - "2.7"
 cache: pip

--- a/features/environment.py
+++ b/features/environment.py
@@ -9,6 +9,9 @@ from worth2.main.tests.factories import (
 
 def before_all(context):
     context.browser = Browser('firefox')
+    # Wait up to 10 seconds for elements to appear.
+    # http://selenium-python.readthedocs.org/en/latest/waits.html#implicit-waits
+    context.browser.driver.implicitly_wait(10)
 
 
 def before_scenario(context, scenario):

--- a/features/steps/auth.py
+++ b/features/steps/auth.py
@@ -36,7 +36,7 @@ def i_am_signed_in_as_a(context, user_type):
     # to create a cookie for it.
     try:
         # 404 pages raise an exception in splinter
-        b.visit('/some_404_page/')
+        b.driver.get('/some_404_page/')
     except HttpResponseError:
         pass
 
@@ -53,10 +53,18 @@ def i_sign_in_as_a_facilitator(context):
     facilitator.save()
 
     b = context.browser
-    b.visit(urlparse.urljoin(context.base_url, '/accounts/login/'))
+    b.driver.get(urlparse.urljoin(context.base_url, '/accounts/login/'))
     b.fill('username', facilitator.username)
     b.fill('password', 'test_pass')
-    b.find_by_css('.form-signin button[type="submit"]').first.click()
+
+    old_url = context.browser.url
+    link = b.driver.find_element_by_css_selector(
+        '.form-signin button[type="submit"]')
+
+    link.click()
+    # If the url didn't change, it might need another click
+    if old_url == context.browser.url:
+        link.click()
 
 
 @when(u'I sign in as a participant')
@@ -71,7 +79,7 @@ def i_sign_in_as_a_participant(context):
     location = Location.objects.first()
 
     b = context.browser
-    b.visit(urlparse.urljoin(context.base_url, '/sign-in-participant/'))
+    b.driver.get(urlparse.urljoin(context.base_url, '/sign-in-participant/'))
     b.select('participant_id', participant.pk)
     b.select('participant_location', location.pk)
     b.choose('participant_destination', '1')

--- a/features/steps/avatars.py
+++ b/features/steps/avatars.py
@@ -3,4 +3,5 @@ from behave import when
 
 @when(u'I select the first avatar')
 def i_select_the_first_avatar(context):
-    context.browser.find_by_css('.avatar-input-label').first.click()
+    context.browser.driver.find_element_by_class_name(
+        'avatar-input-label').click()

--- a/features/steps/goals.py
+++ b/features/steps/goals.py
@@ -17,5 +17,5 @@ def i_fill_in_a_goal_option(context):
 
 @when(u'I click the goal submit button')
 def i_click_the_goal_submit_button(context):
-    context.browser.find_by_css(
-        '.goal-submit-button button[type="submit"]').first.click()
+    context.browser.driver.find_element_by_css_selector(
+        '.goal-submit-button button[type="submit"]').click()

--- a/features/steps/quiz.py
+++ b/features/steps/quiz.py
@@ -3,4 +3,5 @@ from behave import when
 
 @when(u'I select the first quiz option')
 def i_select_the_first_avatar(context):
-    context.browser.find_by_css('.caseanswerlabel').first.click()
+    context.browser.driver.find_element_by_class_name(
+        'caseanswerlabel').click()

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,13 +18,14 @@ ipdb==0.8.1
 traitlets==4.0.0
 ipython_genutils==0.1.0
 decorator==4.0.4
+ptyprocess==0.5
 pexpect==4.0.1
 pickleshare==0.5
 simplegeneric==0.8.1
 path.py==8.1.2
 ipython==4.0.0
 rdflib==4.2.1
-selenium==2.47.1
+selenium==2.48.0
 coverage==4.0.3
 logilab-common==0.63.2
 logilab-astng==0.24.3


### PR DESCRIPTION
I'm experimenting with trying to fix the unreliable "Manage Participant
IDs" step in behave. I've moved some things around, added a fix for
link clicking. I'm calling selenium methods directly now, where
possible, instead of going through splinter. This is to eliminate
a potentially problematic layer of abstraction. If this proves to be
stable I'm planning on eventually phasing out splinter.

I'm using FF 43.0 locally, so I've changed the version number in travis.
    
Selenium 2.48.0 seems to call a place in pexpect that required me to
add the ptyprocess library to requirements.txt.