### PR TITLE
Remove invalid attribute on sign in form

### DIFF
--- a/worth2/templates/main/facilitator_sign_in_participant.html
+++ b/worth2/templates/main/facilitator_sign_in_participant.html
@@ -10,13 +10,11 @@
 
     <h1>Sign In My Participant</h1>
 
-        <form class="form-horizontal" role="form" method="post" action=""">
+    <form class="form-horizontal" role="form" method="post">{% csrf_token %}
 
         <div class="well">
 
         <h2 class="lead">Step 1. Who is my participant?</h2>
-
-        {% csrf_token %}
 
         {% bootstrap_field form.filter_by_cohort layout='horizontal' %}
 


### PR DESCRIPTION
The participant sign in form had `action="""`, which is invalid
HTML. The action attribute isn't necessary for this form so I've
removed it.

I also moved the csrf_token up to the `<form>` tag. This makes it
obvious that this form has a CSRF token when grepping through the
code.