### PR TITLE
explicitly unlock goal review session - PMT #104947

### DIFF
--- a/worth2/templates/goals/goal_check_in_block.html
+++ b/worth2/templates/goals/goal_check_in_block.html
@@ -68,6 +68,9 @@
                     </div><!-- end .checkin-group -->
                     <div class="clearfix"></div>
                     {% empty %}
+                    <script>
+                    var isSectionUnlocked = 1;
+                    </script>
                     <p class="lead">
                         You haven't completed the goal setting activity for this check-in activity, so
                         just continue to the next page.


### PR DESCRIPTION
This is a quick fix for an urgent problem.

This shouldn't cause any problems.. and I want to err on the side of letting
participants through rather them locking them, preventing them from
completing the session.