### PR TITLE
Hide Demo View from Facilitators

### DIFF
--- a/features/index.feature
+++ b/features/index.feature
@@ -6,4 +6,5 @@ Feature: Index Page
 
   Scenario: Facilitator Sign In
     When I sign in as a facilitator
-    Then I see the text "View as Facilitator"
+    Then I don't see the text "Demonstration View"
+    Then I see the text "Intervene"

--- a/worth2/templates/main/facilitator_dashboard.html
+++ b/worth2/templates/main/facilitator_dashboard.html
@@ -1,9 +1,10 @@
 <div class="worth-facilitator-dashboard">
+    {% if request.user.is_staff %}
     <div class="dropdown">
         <button class="btn btn-default dropdown-toggle" type="button"
                 id="sessionDropdownMenu1" data-toggle="dropdown"
                 aria-haspopup="true" aria-expanded="true">
-            View as Facilitator
+            Demonstration View
             <span class="caret"></span>
         </button>
         <ul class="dropdown-menu" aria-labelledby="sessionDropdownMenu1">
@@ -14,6 +15,7 @@
             <li><a href="/pages/session-5/">Session 5</a></li>
         </ul>
     </div>
+    {% endif %}
 
     <h1>
         {% if request.user.first_name %}


### PR DESCRIPTION
Regular facilitators are incorrectly using the demo view for participants. This wreaks havoc on research data collection. Lock this feature down to staff only.