### PR TITLE
add smoketest to check avatar uniqueness

### DIFF
--- a/worth2/main/smoke.py
+++ b/worth2/main/smoke.py
@@ -1,5 +1,6 @@
 from smoketest import SmokeTest
 from django.contrib.auth.models import User
+from .models import Avatar
 
 
 class DBConnectivity(SmokeTest):
@@ -7,3 +8,9 @@ class DBConnectivity(SmokeTest):
         cnt = User.objects.all().count()
         # all we care about is not getting an exception
         self.assertTrue(cnt > -1)
+
+
+class AvatarTest(SmokeTest):
+    def test_single_default(self):
+        cnt = Avatar.objects.filter(is_default=True).count()
+        self.assertTrue(cnt < 2)


### PR DESCRIPTION
The `Avatar` model has an `is_default` field that says:

> If this is the initial avatar for all participants,
>	set this option to True. There can only be one default avatar
>  in the system.

There's a `clean()` method that enforces that if/when it's called, but
it could still be changed by other means, so this adds a smoketest to
make sure this constraint is not violated in production without an alert
being raised.