### PR TITLE
report test coverage and such on all apps

### DIFF
--- a/worth2/settings_shared.py
+++ b/worth2/settings_shared.py
@@ -21,6 +21,10 @@ CACHES = {
 
 PROJECT_APPS = [
     'worth2.main',
+    'worth2.goals',
+    'worth2.protectivebehaviors',
+    'worth2.selftalk',
+    'worth2.ssnm',
 ]
 
 USE_TZ = True


### PR DESCRIPTION
goals, protectivebehaviors, selftalk, and ssnm are not being included in jenkins coverage reporting