### PR TITLE
:arrow_up: Django 1.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 --index-url https://pypi.ccnmtl.columbia.edu/
-Django==1.8.17
+Django==1.9.12
 Markdown==2.6.7
 smartypants==1.8.6
 psycopg2==2.6.2
@@ -46,7 +46,6 @@ django-storages-redux==1.3.2
 
 djangowind==0.16.1
 sorl==3.1
-typogrify==2.0.7
 django-indexer==0.3.0
 django-templatetag-sugar==1.0
 django-paging==0.2.5

--- a/worth2/settings_shared.py
+++ b/worth2/settings_shared.py
@@ -37,7 +37,6 @@ INSTALLED_APPS += [  # noqa
     'sorl.thumbnail',
     'django.contrib.webdesign',
     'ordered_model',
-    'typogrify',
     'bootstrap3',
     'bootstrapform',
     'infranil',


### PR DESCRIPTION
The only thing that seemed to be holding it back to 1.8 was `typogrify`,
which doesn't appear to be used anywhere anyway.