### PR TITLE
Fix GoalCheckIn IntegrityError - PMT #109718

### DIFF
--- a/worth2/goals/mixins.py
+++ b/worth2/goals/mixins.py
@@ -70,17 +70,9 @@ class GoalCheckInViewMixin(object):
                 resp_id = formdata.pop('goal_setting_response_id')
                 resp = get_object_or_404(GoalSettingResponse, pk=resp_id)
                 updated_values = formdata.copy()
-                try:
-                    GoalCheckInResponse.objects.create_or_update(
-                        goal_setting_response=resp,
-                        defaults=updated_values)
-                except:
-                    GoalCheckInResponse.objects.filter(
-                        goal_setting_response=resp,
-                    ).delete()
-
-                    updated_values.update({'goal_setting_response': resp})
-                    GoalCheckInResponse.objects.create(**updated_values)
+                GoalCheckInResponse.objects.update_or_create(
+                    goal_setting_response=resp,
+                    defaults=updated_values)
 
         return formset
 


### PR DESCRIPTION
This problem arose from using a bare `except` clause. I was trying to
call `create_or_update()`, but the method is actually called
`update_or_create()`, so the execution was always failing into the
except clause. There's really no exceptions that I'm expecting here, so
I just removed the try/except.