### PR TITLE
add django-pagetree-epub

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,9 @@ ipython==5.2.2
 
 rdflib==4.2.2
 
+Genshi==0.7
+epubbuilder==0.1.4
+
 selenium==2.48.0
 coverage==4.3.4
 logilab-common==1.3.0
@@ -87,6 +90,7 @@ django-treebeard==4.1.0
 django-pagetree==1.3.0
 django-pageblocks==1.0.4
 django-quizblock==1.2.2
+django-pagetree-epub==0.1.0
 django-markwhat==1.5.1
 gunicorn==19.6.0
 django-infranil==1.1.0

--- a/worth2/settings_shared.py
+++ b/worth2/settings_shared.py
@@ -52,6 +52,7 @@ INSTALLED_APPS += [  # noqa
     'worth2.goals',
     'worth2.selftalk',
     'behave_django',
+    'pagetreeepub',
 ]
 
 REST_FRAMEWORK = {
@@ -92,3 +93,12 @@ MESSAGE_TAGS = {
 }
 
 BEHAVE_DEBUG_ON_ERROR = False
+
+# epub settings
+EPUB_ALLOWED_BLOCKS = [
+    'Text Block', 'HTML Block', 'Pull Quote'
+]
+EPUB_TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), "templates/epub")
+EPUB_TITLE = "WORTH epub"
+EPUB_CREATOR = "CTL"
+EPUB_PUBLICATION = "2017"

--- a/worth2/templates/epub/container.xml
+++ b/worth2/templates/epub/container.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--!
+Copyright (c) 2012, Bin Tan
+This file is distributed under the BSD Licence. See python-epub-builder-license.txt for details.
+-->
+<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>

--- a/worth2/templates/epub/content.opf
+++ b/worth2/templates/epub/content.opf
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!--!
+Copyright (c) 2012, Bin Tan
+This file is distributed under the BSD Licence. See python-epub-builder-license.txt for details.
+-->
+<opf:package xmlns:opf="http://www.idpf.org/2007/opf"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:py="http://genshi.edgewall.org/"
+    unique-identifier="bookid" version="2.0">
+  <opf:metadata >
+    <dc:identifier id="bookid">urn:uuid:${book.UUID}</dc:identifier>
+    <dc:language>${book.lang}</dc:language>
+    <dc:title>${book.title}</dc:title>
+    <py:for each="name, role in book.creators">
+    <dc:creator opf:role="$role">$name</dc:creator>
+    </py:for>
+    <py:for each="beginTag, content, endTag in book.getMetaTags()">
+    ${Markup(beginTag)}$content${Markup(endTag)}
+    </py:for>
+    <opf:meta name="cover" content="${book.coverImage.id}" py:if="book.coverImage"/>
+  </opf:metadata>
+  <opf:manifest>
+    <opf:item id="ncxtoc" media-type="application/x-dtbncx+xml" href="toc.ncx"/>
+    <py:for each="item in book.getAllItems()">
+    <opf:item id="${item.id}" media-type="${item.mimeType}" href="${item.destPath}"/>
+    </py:for>
+  </opf:manifest>
+  <opf:spine toc="ncxtoc">
+    <py:for each="_, item, linear in book.getSpine()">
+    <opf:itemref idref="${item.id}" linear="${'yes' if linear else 'no'}"/>
+    </py:for>
+  </opf:spine>
+  <opf:guide py:if="book.guide">
+    <py:for each="href, title, type in book.getGuide()">
+    <opf:reference href="$href" type="$type" title="$title"/>
+    </py:for>
+  </opf:guide>
+</opf:package>

--- a/worth2/templates/epub/ez-section.html
+++ b/worth2/templates/epub/ez-section.html
@@ -1,0 +1,27 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:py="http://genshi.edgewall.org/">
+<!--!
+Copyright (c) 2012, Bin Tan
+This file is distributed under the BSD Licence. See python-epub-builder-license.txt for details.
+-->
+<head>
+  <title>${section.title}</title>
+  <style type="text/css">
+h1 { text-align: center; }
+${section.css}
+  </style>
+</head>
+<body>
+  <h1>${section.title}</h1>
+  <py:for each="paragraph in section.text">
+  <p>
+    <py:choose test="type(paragraph)">
+    <py:when test="type([])">
+		<py:choose test="className" py:for="text, className in paragraph"><py:when test="''">$text</py:when><py:otherwise><span class="$className">$text</span></py:otherwise></py:choose>
+    </py:when>
+    <py:otherwise>$paragraph</py:otherwise>
+    </py:choose>
+  </p>
+  </py:for>
+</body>
+</html>

--- a/worth2/templates/epub/form.html
+++ b/worth2/templates/epub/form.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+
+{% block content %}
+    <form action="." method="post">
+        {% csrf_token %}
+        <input type="submit" class="btn btn-primary" value="generate epub" />
+    </form>
+{% endblock %}

--- a/worth2/templates/epub/image.html
+++ b/worth2/templates/epub/image.html
@@ -1,0 +1,20 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:py="http://genshi.edgewall.org/">
+<!--!
+Copyright (c) 2012, Bin Tan
+This file is distributed under the BSD Licence. See python-epub-builder-license.txt for details.
+-->
+<head>
+  <title>${item.destPath}</title>
+  <style type="text/css">
+div, img {
+	border: 0;
+	margin: 0;
+	padding: 0;
+}
+  </style>
+</head>
+<body>
+  <div><img src="${item.destPath}" alt="${item.destPath}"/></div>
+</body>
+</html>

--- a/worth2/templates/epub/section.html
+++ b/worth2/templates/epub/section.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><title>{{section.label}}</title></head>
+<body>
+{% if not section.pageblock_set.all.count %}
+<p>[EMPTY SECTION]</p>
+{% else %}
+
+{% for block in blocks %}
+  {% if block.label %}
+    <h2>{{block.label}}</h2>
+  {% endif %}
+
+  {% if block.unrenderable %}
+    <p><i>Unrenderable Block: {{block.content_object.display_name}}</i></p>
+  {% else %}
+    {% if block.is_image_block %}
+      <div><img src="{{block.epub_image_filename}}" /></div>
+    {% else %}
+      {{block.render|safe}}
+    {% endif %}
+  {% endif %}
+
+{% endfor %}
+
+{% endif %}
+</body>
+</html>

--- a/worth2/templates/epub/title-page.html
+++ b/worth2/templates/epub/title-page.html
@@ -1,0 +1,26 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:py="http://genshi.edgewall.org/">
+<!--!
+Copyright (c) 2012, Bin Tan
+This file is distributed under the BSD Licence. See python-epub-builder-license.txt for details.
+-->
+<head>
+  <title>${book.title}</title>
+  <style type="text/css">
+.title, .authors {
+  text-align: center;
+}
+span.author {
+  margin: 1em;
+}
+  </style>
+</head>
+<body>
+  <h1 class="title">${book.title}</h1>
+  <h3 class="authors">
+  <py:for each="creator, _ in book.creators">
+  <span class="author">$creator</span>
+  </py:for>
+  </h3>
+</body>
+</html>

--- a/worth2/templates/epub/toc.html
+++ b/worth2/templates/epub/toc.html
@@ -1,0 +1,36 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:py="http://genshi.edgewall.org/">
+<!--!
+Copyright (c) 2012, Bin Tan
+This file is distributed under the BSD Licence. See python-epub-builder-license.txt for details.
+-->
+<head>
+  <title>${book.title}</title>
+  <style type="text/css">
+.tocEntry-1 {
+}
+.tocEntry-2 {
+	text-indent: 1em;
+}
+.tocEntry-3 {
+	text-indent: 2em;
+}
+.tocEntry-4 {
+	text-indent: 3em;
+}
+  </style>
+</head>
+<body>
+  <py:def function="tocEntry(node)">
+    <div class="tocEntry-${node.depth}">
+      <a href="${node.href}">${node.title}</a>
+    </div>
+    <py:for each="child in node.children">
+    ${tocEntry(child)}
+    </py:for>
+  </py:def>
+  <py:for each="child in book.getTocMapRoot().children">
+  ${tocEntry(child)}
+  </py:for>
+</body>
+</html>

--- a/worth2/templates/epub/toc.ncx
+++ b/worth2/templates/epub/toc.ncx
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--!
+Copyright (c) 2012, Bin Tan
+This file is distributed under the BSD Licence. See python-epub-builder-license.txt for details.
+-->
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/"
+    xmlns:py="http://genshi.edgewall.org/"
+    version="2005-1">
+  <head>
+    <meta name="dtb:uid" content="urn:uuid:${book.UUID}"/>
+    <meta name="dtb:depth" content="${book.getTocMapHeight()}"/>
+    <meta name="dtb:totalPageCount" content="0"/>
+    <meta name="dtb:maxPageNumber" content="0"/>
+  </head>
+  <docTitle>
+    <text>${book.title}</text>
+  </docTitle>
+  <navMap>
+    <py:def function="navPoint(node)">
+    <navPoint id="navPoint-${node.playOrder}" playOrder="${node.playOrder}">
+      <navLabel><text>${node.title}</text></navLabel>
+      <content src="${node.href}"/>
+      <py:for each="child in node.children">
+      ${navPoint(child)}
+      </py:for>
+    </navPoint>
+    </py:def>
+    <py:for each="child in book.getTocMapRoot().children">
+    ${navPoint(child)}
+    </py:for>
+  </navMap>
+</ncx>

--- a/worth2/urls.py
+++ b/worth2/urls.py
@@ -5,7 +5,10 @@ from django.contrib import admin
 from django.contrib.auth.decorators import user_passes_test
 from django.conf import settings
 from django.views.generic import TemplateView
+
 from pagetree.generic.views import EditView, InstructorView
+from pagetreeepub.views import EpubExporterView
+
 from rest_framework import routers
 
 from worth2.main import apiviews, auth, views
@@ -100,6 +103,9 @@ urlpatterns = patterns(
 
     # Social Support Network Map activity
     url(r'^ssnm/api/', include(ssnm_rest_router.urls)),
+
+    url('^epub/$', user_passes_test(lambda u: u.is_superuser)(
+        EpubExporterView.as_view()), name='epub-export'),
 )
 
 if settings.DEBUG:


### PR DESCRIPTION
That library is an experimental feature that started out in forest. I
pulled it out into its own module so we can use it here.

It builds a very basic epub book out of a pagetree site.

As you will probably see, it is very, very barebones at the moment, only
supporting a couple of basic blocks. We never really got very far on
that in Forest because we didn't actually having anything driving it.

Especially since WORTH is mostly video and interactive content, the epub
that it currently generates is laughably unusable, with 'Unrenderable
Block' for most of the content.

But, we have to start somewhere. With this in place, we can start
working block by block to figure out how it should be rendered in an
epub, or to replace it outright with something else.