### PR TITLE
remove study_id_validator()

### DIFF
--- a/worth2/main/migrations/0019_auto_20150701_1544.py
+++ b/worth2/main/migrations/0019_auto_20150701_1544.py
@@ -17,6 +17,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='participant',
             name='study_id',
-            field=models.CharField(db_index=True, unique=True, max_length=255, validators=[django.core.validators.RegexValidator(regex=b'^[1-2]\\d[0-1]\\d[0-3]\\d\\d\\d[0-2]\\d[0-5]\\d$', message=b"That study ID isn't valid. The format is: YYMMDDLLHHMM (where LL is the two-digit location code)."), worth2.main.models.study_id_validator]),
+            field=models.CharField(db_index=True, unique=True, max_length=255, validators=[django.core.validators.RegexValidator(regex=b'^[1-2]\\d[0-1]\\d[0-3]\\d\\d\\d[0-2]\\d[0-5]\\d$', message=b"That study ID isn't valid. The format is: YYMMDDLLHHMM (where LL is the two-digit location code).")]),
         ),
     ]

--- a/worth2/main/migrations/0021_auto_20151026_0929.py
+++ b/worth2/main/migrations/0021_auto_20151026_0929.py
@@ -17,6 +17,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='participant',
             name='study_id',
-            field=models.CharField(db_index=True, unique=True, max_length=255, validators=[django.core.validators.RegexValidator(regex=b'^[1-2]\\d[0-1]\\d[0-3]\\d\\d\\d[0-2]\\d[0-5]\\d$', message=b"That study ID isn't valid. The format is: YYMMDDLLHHMM (where LL is the two-digit location code)."), worth2.main.models.study_id_validator]),
+            field=models.CharField(db_index=True, unique=True, max_length=255, validators=[django.core.validators.RegexValidator(regex=b'^[1-2]\\d[0-1]\\d[0-3]\\d\\d\\d[0-2]\\d[0-5]\\d$', message=b"That study ID isn't valid. The format is: YYMMDDLLHHMM (where LL is the two-digit location code).")]),
         ),
     ]

--- a/worth2/main/models.py
+++ b/worth2/main/models.py
@@ -183,11 +183,6 @@ study_id_regex_validator = RegexValidator(
     'The format is: RRHHMMDDMMYBS')
 
 
-def study_id_validator(value):
-    """Validate study ID for anything the regex can't capture."""
-    pass
-
-
 # For now, accept any 3-digit number as the cohort ID.
 cohort_id_validator = RegexValidator(
     regex=r'^\d{3}$',


### PR DESCRIPTION
function does nothing. Looks like it was once used for doing some
validation on a migration, but has since been emptied out. No point in
keeping it around. Removed the references to it from
migrations. Obviously, if those migrations run, they won't do whatever
validation the function used to do, but that's been true ever since it
was turned into a no-op.