### PR TITLE
Revert "Django 1.11"

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -29,7 +29,6 @@ def before_scenario(context, scenario):
     # the tests.
     password = generate_password(participant.user.username)
     participant.user.set_password(password)
-    participant.user.is_active = True
     participant.user.save()
 
 

--- a/features/steps/auth.py
+++ b/features/steps/auth.py
@@ -48,8 +48,7 @@ def i_am_signed_in_as_a(context, user_type):
 
 @when(u'I sign in as a facilitator')
 def i_sign_in_as_a_facilitator(context):
-    facilitator = User.objects.filter(
-        username__startswith='facilitator').first()
+    facilitator = User.objects.filter(is_active=True).first()
 
     d = context.driver
     d.get(urlparse.urljoin(context.base_url, '/accounts/login/'))
@@ -90,8 +89,7 @@ def i_sign_in_as_a_participant(context):
 @when(u'I sign in as the facilitator from a session')
 def i_sign_in_as_the_facilitator_from_a_session(context):
     d = context.driver
-    facilitator = User.objects.filter(
-        username__startswith='facilitator').first()
+    facilitator = User.objects.filter(is_active=True).first()
 
     try:
         # If the window is narrow, we need to click the collapse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 --index-url https://pypi.ccnmtl.columbia.edu/
-Django==1.11
+Django==1.9.13
 Markdown==2.6.8
 smartypants==2.0.0
 psycopg2==2.7.1
@@ -14,7 +14,6 @@ mccabe==0.6.1
 
 pycodestyle==2.3.1
 
-pytz==2017.2
 enum34==1.1.6
 configparser==3.5.0
 flake8==3.3.0

--- a/worth2/main/auth.py
+++ b/worth2/main/auth.py
@@ -26,7 +26,7 @@ def generate_password(username):
 
 
 def user_is_participant(user):
-    return not user.is_anonymous and \
+    return not user.is_anonymous() and \
         (hasattr(user, 'profile') and user.profile.is_participant())
 
 

--- a/worth2/main/models.py
+++ b/worth2/main/models.py
@@ -25,7 +25,7 @@ class InactiveUserProfile(BaseUserProfile):
     is_archived = models.BooleanField(default=False)
 
     def is_participant(self):
-        return True
+        return (not self.user.is_active)
 
 
 class Avatar(OrderedModel):

--- a/worth2/main/tests/mixins.py
+++ b/worth2/main/tests/mixins.py
@@ -37,3 +37,6 @@ class LoggedInParticipantTestMixin(object):
         login = self.client.login(username=self.u.username,
                                   password=generate_password(self.u.username))
         assert(login is True)
+
+        self.u.is_active = False
+        self.u.save()

--- a/worth2/main/tests/test_views.py
+++ b/worth2/main/tests/test_views.py
@@ -48,10 +48,10 @@ class AvatarSelectorBlockTest(LoggedInParticipantTestMixin, TestCase):
     def test_post(self):
         pageblock = self.root.get_first_child().pageblock_set.first()
         param_name = 'pageblock-%d-avatar-id' % pageblock.pk
-
         r = self.client.post(self.url, {
             param_name: self.avatar1.pk,
         })
+
         self.assertEqual(r.status_code, 302)
         participant = Participant.objects.get(pk=self.participant.pk)
         self.assertEqual(participant.avatar, self.avatar1)
@@ -212,7 +212,6 @@ class SignInParticipantTest(LoggedInFacilitatorTestMixin, TestCase):
 
         password = generate_password(participant.user.username)
         participant.user.set_password(password)
-        participant.user.is_active = True
         participant.user.save()
         response = self.client.post(
             reverse('sign-in-participant'), {
@@ -255,7 +254,6 @@ class SignInParticipantTest(LoggedInFacilitatorTestMixin, TestCase):
 
         password = generate_password(participant.user.username)
         participant.user.set_password(password)
-        participant.user.is_active = True
         participant.user.save()
         response = self.client.post(
             reverse('sign-in-participant'), {
@@ -300,7 +298,6 @@ class SignInParticipantTest(LoggedInFacilitatorTestMixin, TestCase):
 
         password = generate_password(participant.user.username)
         participant.user.set_password(password)
-        participant.user.is_active = True
         participant.user.save()
         response = self.client.post(
             reverse('sign-in-participant'), {

--- a/worth2/main/views.py
+++ b/worth2/main/views.py
@@ -244,6 +244,7 @@ class SignInParticipant(FormView):
 
         if user is not None:
             login(self.request, user)
+
             module_num = int(form.cleaned_data.get('participant_destination'))
             upv = participant.last_access_in_module(module_num)
             if upv:

--- a/worth2/templates/main/avatar_selector_block.html
+++ b/worth2/templates/main/avatar_selector_block.html
@@ -2,7 +2,7 @@
 
 <div class="worth-avatars">
 
-    {% if user.profile.participant.avatar %}
+    {% if user.is_active or user.profile.participant.avatar %}
 
     <p>Here is the avatar that you selected!</p>
 

--- a/worth2/urls.py
+++ b/worth2/urls.py
@@ -1,6 +1,5 @@
 import os.path
 import django.contrib.auth.views
-import django.views.static
 import djangowind.views
 
 from django.conf.urls import include, url
@@ -61,7 +60,7 @@ urlpatterns = [
     url(r'smoketest/', include('smoketest.urls')),
     url(r'infranil/', include('infranil.urls')),
     url(r'^uploads/(?P<path>.*)$',
-        django.views.static.serve, {'document_root': settings.MEDIA_ROOT}),
+        'django.views.static.serve', {'document_root': settings.MEDIA_ROOT}),
 
     url(r'^pagetree/', include('pagetree.urls')),
     url(r'^quizblock/', include('quizblock.urls')),


### PR DESCRIPTION
Reverts ccnmtl/worth2#826

This branch breaks the admin from logging in the participant in the sign-in-participant form, because there's a call to `authenticate` which no longer works. I need to address this before updating to django 1.11.