### PR TITLE
Goal Check-In: Hide submit button if goal setting skipped

### DIFF
--- a/worth2/templates/goals/goal_check_in_block.html
+++ b/worth2/templates/goals/goal_check_in_block.html
@@ -67,20 +67,20 @@
                         <div class="clearfix"></div>
                     </div><!-- end .checkin-group -->
                     <div class="clearfix"></div>
+
+                    {% if forloop.last %}
+                        <div class="form-group goal-submit-button">
+                            <button type="submit"
+                                    class="btn btn-primary btn-lg">Submit</button>
+                        </div>
+                    {% endif %}
+
                     {% empty %}
                     <p class="lead">
                         You haven't completed the goal setting activity for this check-in activity, so
                         just continue to the next page.
                     </p>
                     {% endfor %}
-
-                    {% if goal_checkin_context %}
-                    <div class="form-group goal-submit-button">
-                        <button type="submit"
-                                class="btn btn-primary btn-lg">Submit</button>
-                    </div>
-                    {% endif %}
-
                 </form><!-- end .form-horizontal -->
             </div>
 


### PR DESCRIPTION
The `goal_checkin_context` is a ZipFile rendering the check at Line 76 always True, even if there was no content. Resolving by using the `forloop.last` tag within the loop.