### PR TITLE
Fix Practical/Emotional support saving - EPFS-50

### DIFF
--- a/media/js/src/ssnm/serializers/application.js
+++ b/media/js/src/ssnm/serializers/application.js
@@ -1,3 +1,7 @@
 (function() {
-    Ssnm.ApplicationSerializer = DS.JSONAPISerializer;
+    Ssnm.ApplicationSerializer = DS.JSONAPISerializer.extend({
+        keyForAttribute: function(attr) {
+            return Em.String.underscore(attr);
+        }
+    });
 })();


### PR DESCRIPTION
The ember-data adapter was serializing these fields as dash-case instead
of camelCase. 

```
provides-emotional-support: false
provides-practical-support: true
```

Apparently that change was in the JSON:API spec:

https://guides.emberjs.com/release/models/customizing-serializers/

But our backend doesn't support that... even though it is using
JSON:API. Anyways, customizing the serializer to snake_case its
attributes fixes this.