### PR TITLE
Use pylibmc for memcached bindings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -103,7 +103,8 @@ django-smtp-ssl==1.0
 
 inflection==0.3.1
 unicodecsv==0.14.1
-python-memcached==1.59
+# memcached
+pylibmc==1.6.1
 
 parse-type==0.4.2
 parse==1.14.0

--- a/worth2/settings_production.py
+++ b/worth2/settings_production.py
@@ -16,7 +16,7 @@ locals().update(
 
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
         'LOCATION': '127.0.0.1:11211',
     }
 }

--- a/worth2/settings_staging.py
+++ b/worth2/settings_staging.py
@@ -16,7 +16,7 @@ locals().update(
 
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
         'LOCATION': '127.0.0.1:11211',
     }
 }


### PR DESCRIPTION
This library is better maintained than python-memcached.