### PR TITLE
INFRA-2634: Update ctlsettings to 0.3.0 for ALB Migration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -109,7 +109,7 @@ linecache2==1.0.0
 behave-django==1.4.0
 django-ga-context==0.1.0
 
-ctlsettings==0.2.0
+ctlsettings==0.3.0
 
 pbr==6.0.0
 PyYAML>=3.10.0 # MIT


### PR DESCRIPTION
Update to ctlsettings 0.3.0 which include changes for AWS migration.