### PR TITLE
Downgrade django-pageblocks to 1.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -84,7 +84,7 @@ confusable_homoglyphs==3.3.1
 django-registration==3.4
 django-treebeard==4.7.1
 django-pagetree==1.5.0
-django-pageblocks==2.0.0
+django-pageblocks==1.3.0
 django-quizblock==1.3.0
 django-pagetree-epub==0.3.0
 


### PR DESCRIPTION
version 2.0.0 no longer exists.